### PR TITLE
Move to http-interop/http-factory version 0.3.0.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,12 @@
         "php": "^7.0",
         "psr/http-message": "^1.0",
         "php-http/message-factory": "^1.0",
-        "http-interop/http-factory": "^0.2"
+        "http-interop/http-factory": "^0.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",
         "php-http/psr7-integration-tests": "dev-master",
-        "http-interop/http-factory-tests": "^0.2.1"
+        "http-interop/http-factory-tests": "^0.3"
     },
     "provide": {
         "psr/http-message-implementation": "1.0"

--- a/src/Factory/ServerRequestFactory.php
+++ b/src/Factory/ServerRequestFactory.php
@@ -9,29 +9,29 @@ use Nyholm\Psr7\ServerRequest;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ * @author Martijn van der Ven <martijn@vanderven.se>
  */
 class ServerRequestFactory implements ServerRequestFactoryInterface
 {
-    public function createServerRequest(array $server, $method = null, $uri = null)
+    public function createServerRequest($method, $uri)
     {
-        if (null === $method && isset($server['REQUEST_METHOD'])) {
-            $method = $server['REQUEST_METHOD'];
-        }
-        if (null === $method) {
+        return new ServerRequest($method, $uri);
+    }
+
+    public function createServerRequestFromArray(array $server)
+    {
+        if (!isset($server['REQUEST_METHOD'])) {
             throw new \InvalidArgumentException('Cannot determine HTTP method');
         }
         // TODO: find a MUCH better way
-        if (null === $uri) {
-            $SERVER = $_SERVER;
-            $_SERVER = $server;
-            // Until https://github.com/guzzle/psr7/pull/116 is resolved
-            if (!isset($_SERVER['HTTPS'])) {
-                $_SERVER['HTTPS'] = 'off';
-            }
-            $uri = ServerRequest::getUriFromGlobals();
-            $_SERVER = $SERVER;
-            unset($SERVER);
+        $method = $server['REQUEST_METHOD'];
+        $SERVER = $_SERVER;
+        $_SERVER = $server;
+        // Until https://github.com/guzzle/psr7/pull/116 is resolved
+        if (!isset($_SERVER['HTTPS'])) {
+            $_SERVER['HTTPS'] = 'off';
         }
+        $uri = ServerRequest::getUriFromGlobals();
 
         return new ServerRequest($method, $uri, [], null, '1.1', $server);
     }


### PR DESCRIPTION
This updates the ServerRequestFactoryInterface implementation to match the latest version. Claiming PSR-17 support in the README is now true, once again! 😀

[See the differences between 0.2.0 and 0.3.0 on GitHub.](https://github.com/http-interop/http-factory/compare/0.2.0...0.3.0)