### PR TITLE
Move instantiation code to factories.

### DIFF
--- a/src/Factory/ServerRequestFactory.php
+++ b/src/Factory/ServerRequestFactory.php
@@ -82,7 +82,7 @@ class ServerRequestFactory implements ServerRequestFactoryInterface
      *
      * @return array
      */
-    public static function normalizeFiles(array $files): array
+    private static function normalizeFiles(array $files): array
     {
         $normalized = [];
 

--- a/src/Factory/ServerRequestFactory.php
+++ b/src/Factory/ServerRequestFactory.php
@@ -26,7 +26,7 @@ class ServerRequestFactory implements ServerRequestFactoryInterface
     public function createServerRequestFromArray(array $server): ServerRequestInterface
     {
         if (!isset($server['REQUEST_METHOD'])) {
-            throw new \InvalidArgumentException('Cannot determine HTTP method');
+            throw new InvalidArgumentException('Cannot determine HTTP method');
         }
         $method = $server['REQUEST_METHOD'];
 
@@ -35,11 +35,13 @@ class ServerRequestFactory implements ServerRequestFactoryInterface
             $uri = $uri->withScheme('http');
         }
 
-        return new ServerRequest($method, $uri, [], null, '1.1', $server);
+        $protocol = isset($server['SERVER_PROTOCOL']) ? str_replace('HTTP/', '', $server['SERVER_PROTOCOL']) : '1.1';
+
+        return new ServerRequest($method, $uri, [], null, $protocol, $server);
     }
 
     /**
-     * Create a new server request from server variables.
+     * Create a new server request from a set of arrays.
      *
      * @param array $server Typically $_SERVER or similar structure.
      * @param array $cookie Typically $_COOKIE or similar structure.
@@ -47,22 +49,30 @@ class ServerRequestFactory implements ServerRequestFactoryInterface
      * @param array $post   Typically $_POST or similar structure.
      * @param array $files  Typically $_FILES or similar structure.
      *
+     * @throws InvalidArgumentException If no valid method or URI can be determined.
+     *
      * @return ServerRequestInterface
      */
-    public function createServerRequestFromGlobals(
+    public function createServerRequestFromArrays(
         array $server,
         array $cookie,
         array $get,
         array $post,
         array $files
     ): ServerRequestInterface {
-        $method = isset($server['REQUEST_METHOD']) ? $server['REQUEST_METHOD'] : 'GET';
-        $headers = function_exists('getallheaders') ? getallheaders() : [];
+        if (!isset($server['REQUEST_METHOD'])) {
+            throw new InvalidArgumentException('Cannot determine HTTP method');
+        }
+        $method = $server['REQUEST_METHOD'];
+
         $uri = (new UriFactory())->createUriFromArray($server);
         if ($uri->getScheme() === '') {
             $uri = $uri->withScheme('http');
         }
+
         $protocol = isset($server['SERVER_PROTOCOL']) ? str_replace('HTTP/', '', $server['SERVER_PROTOCOL']) : '1.1';
+
+        $headers = function_exists('getallheaders') ? getallheaders() : [];
 
         $serverRequest = new ServerRequest($method, $uri, $headers, null, $protocol, $server);
 
@@ -71,6 +81,20 @@ class ServerRequestFactory implements ServerRequestFactoryInterface
             ->withQueryParams($get)
             ->withParsedBody($post)
             ->withUploadedFiles(self::normalizeFiles($files));
+    }
+
+    /**
+     * Create a new server request from the current environment variables.
+     *
+     * @return ServerRequestInterface
+     */
+    public function createServerRequestFromGlobals(): ServerRequestInterface
+    {
+        $server = $_SERVER;
+        if (false === isset($server['REQUEST_METHOD'])) {
+            $server['REQUEST_METHOD'] = 'GET';
+        }
+        return $this->createServerRequestFromArrays($_SERVER, $_COOKIE, $_GET, $_POST, $_FILES);
     }
 
     /**

--- a/src/Factory/ServerRequestFactory.php
+++ b/src/Factory/ServerRequestFactory.php
@@ -4,8 +4,13 @@ declare(strict_types=1);
 
 namespace Nyholm\Psr7\Factory;
 
+use InvalidArgumentException;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\UploadedFileInterface;
 use Interop\Http\Factory\ServerRequestFactoryInterface;
 use Nyholm\Psr7\ServerRequest;
+use Nyholm\Psr7\Factory\UriFactory;
+use Nyholm\Psr7\UploadedFile;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
@@ -13,26 +18,140 @@ use Nyholm\Psr7\ServerRequest;
  */
 class ServerRequestFactory implements ServerRequestFactoryInterface
 {
-    public function createServerRequest($method, $uri)
+    public function createServerRequest($method, $uri): ServerRequestInterface
     {
         return new ServerRequest($method, $uri);
     }
 
-    public function createServerRequestFromArray(array $server)
+    public function createServerRequestFromArray(array $server): ServerRequestInterface
     {
         if (!isset($server['REQUEST_METHOD'])) {
             throw new \InvalidArgumentException('Cannot determine HTTP method');
         }
-        // TODO: find a MUCH better way
         $method = $server['REQUEST_METHOD'];
-        $SERVER = $_SERVER;
-        $_SERVER = $server;
-        // Until https://github.com/guzzle/psr7/pull/116 is resolved
-        if (!isset($_SERVER['HTTPS'])) {
-            $_SERVER['HTTPS'] = 'off';
+
+        $uri = (new UriFactory())->createUriFromArray($server);
+        if ($uri->getScheme() === '') {
+            $uri = $uri->withScheme('http');
         }
-        $uri = ServerRequest::getUriFromGlobals();
 
         return new ServerRequest($method, $uri, [], null, '1.1', $server);
+    }
+
+    /**
+     * Create a new server request from server variables.
+     *
+     * @param array $server Typically $_SERVER or similar structure.
+     * @param array $cookie Typically $_COOKIE or similar structure.
+     * @param array $get    Typically $_GET or similar structure.
+     * @param array $post   Typically $_POST or similar structure.
+     * @param array $files  Typically $_FILES or similar structure.
+     *
+     * @return ServerRequestInterface
+     */
+    public function createServerRequestFromGlobals(
+        array $server,
+        array $cookie,
+        array $get,
+        array $post,
+        array $files
+    ): ServerRequestInterface {
+        $method = isset($server['REQUEST_METHOD']) ? $server['REQUEST_METHOD'] : 'GET';
+        $headers = function_exists('getallheaders') ? getallheaders() : [];
+        $uri = (new UriFactory())->createUriFromArray($server);
+        if ($uri->getScheme() === '') {
+            $uri = $uri->withScheme('http');
+        }
+        $protocol = isset($server['SERVER_PROTOCOL']) ? str_replace('HTTP/', '', $server['SERVER_PROTOCOL']) : '1.1';
+
+        $serverRequest = new ServerRequest($method, $uri, $headers, null, $protocol, $server);
+
+        return $serverRequest
+            ->withCookieParams($cookie)
+            ->withQueryParams($get)
+            ->withParsedBody($post)
+            ->withUploadedFiles(self::normalizeFiles($files));
+    }
+
+    /**
+     * Return an UploadedFile instance array.
+     *
+     * @param array $files A array which respect $_FILES structure
+     *
+     * @throws InvalidArgumentException for unrecognized values
+     *
+     * @return array
+     */
+    public static function normalizeFiles(array $files): array
+    {
+        $normalized = [];
+
+        foreach ($files as $key => $value) {
+            if ($value instanceof UploadedFileInterface) {
+                $normalized[$key] = $value;
+            } elseif (is_array($value) && isset($value['tmp_name'])) {
+                $normalized[$key] = self::createUploadedFileFromSpec($value);
+            } elseif (is_array($value)) {
+                $normalized[$key] = self::normalizeFiles($value);
+                continue;
+            } else {
+                throw new InvalidArgumentException('Invalid value in files specification');
+            }
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * Create and return an UploadedFile instance from a $_FILES specification.
+     *
+     * If the specification represents an array of values, this method will
+     * delegate to normalizeNestedFileSpec() and return that return value.
+     *
+     * @param array $value $_FILES struct
+     *
+     * @return array|UploadedFileInterface
+     */
+    private static function createUploadedFileFromSpec(array $value)
+    {
+        if (is_array($value['tmp_name'])) {
+            return self::normalizeNestedFileSpec($value);
+        }
+
+        return new UploadedFile(
+            $value['tmp_name'],
+            (int) $value['size'],
+            (int) $value['error'],
+            $value['name'],
+            $value['type']
+        );
+    }
+
+    /**
+     * Normalize an array of file specifications.
+     *
+     * Loops through all nested files and returns a normalized array of
+     * UploadedFileInterface instances.
+     *
+     * @param array $files
+     *
+     * @return UploadedFileInterface[]
+     */
+    private static function normalizeNestedFileSpec(array $files = []): array
+    {
+        $normalizedFiles = [];
+
+        foreach (array_keys($files['tmp_name']) as $key) {
+            $spec = [
+                'tmp_name' => $files['tmp_name'][$key],
+                'size' => $files['size'][$key],
+                'error' => $files['error'][$key],
+                'name' => $files['name'][$key],
+                'type' => $files['type'][$key],
+            ];
+            $normalizedFiles[$key] = self::createUploadedFileFromSpec($spec);
+        }
+
+        return $normalizedFiles;
     }
 }

--- a/src/Factory/UriFactory.php
+++ b/src/Factory/UriFactory.php
@@ -13,12 +13,50 @@ use Psr\Http\Message\UriInterface;
  */
 class UriFactory implements \Http\Message\UriFactory, UriFactoryInterface
 {
-    public function createUri($uri = '')
+    public function createUri($uri = ''): UriInterface
     {
         if ($uri instanceof UriInterface) {
             return $uri;
         }
 
         return new Uri($uri);
+    }
+
+    /**
+     * Create a new uri from server variable.
+     *
+     * @param array $server Typically $_SERVER or similar structure.
+     *
+     * @return UriInterface
+     */
+    public function createUriFromArray(array $server): UriInterface
+    {
+        $uri = new Uri('');
+
+        if (isset($server['REQUEST_SCHEME'])) {
+            $uri = $uri->withScheme($server['REQUEST_SCHEME']);
+        } elseif (isset($server['HTTPS'])) {
+            $uri = $uri->withScheme($server['HTTPS'] === 'on' ? 'https' : 'http');
+        }
+
+        if (isset($server['HTTP_HOST'])) {
+            $uri = $uri->withHost($server['HTTP_HOST']);
+        } elseif (isset($server['SERVER_NAME'])) {
+            $uri = $uri->withHost($server['SERVER_NAME']);
+        }
+
+        if (isset($server['SERVER_PORT'])) {
+            $uri = $uri->withPort($server['SERVER_PORT']);
+        }
+
+        if (isset($server['REQUEST_URI'])) {
+            $uri = $uri->withPath(current(explode('?', $server['REQUEST_URI'])));
+        }
+
+        if (isset($server['QUERY_STRING'])) {
+            $uri = $uri->withQuery($server['QUERY_STRING']);
+        }
+
+        return $uri;
     }
 }

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -5,6 +5,8 @@ namespace Tests\Nyholm\Psr7;
 use Nyholm\Psr7\ServerRequest;
 use Nyholm\Psr7\UploadedFile;
 use Nyholm\Psr7\Uri;
+use Nyholm\Psr7\Factory\ServerRequestFactory;
+use Nyholm\Psr7\Factory\UriFactory;
 
 /**
  * @covers \Nyholm\Psr7\ServerRequest
@@ -260,7 +262,7 @@ class ServerRequestTest extends \PHPUnit_Framework_TestCase
      */
     public function testNormalizeFiles($files, $expected)
     {
-        $result = ServerRequest::normalizeFiles($files);
+        $result = ServerRequestFactory::normalizeFiles($files);
 
         $this->assertEquals($expected, $result);
     }
@@ -269,7 +271,7 @@ class ServerRequestTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('InvalidArgumentException', 'Invalid value in files specification');
 
-        ServerRequest::normalizeFiles(['test' => 'something']);
+        ServerRequestFactory::normalizeFiles(['test' => 'something']);
     }
 
     public function dataGetUriFromGlobals()
@@ -338,14 +340,12 @@ class ServerRequestTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetUriFromGlobals($expected, $serverParams)
     {
-        $_SERVER = $serverParams;
-
-        $this->assertEquals(new Uri($expected), ServerRequest::getUriFromGlobals());
+        $this->assertEquals(new Uri($expected), (new UriFactory())->createUriFromArray($serverParams));
     }
 
     public function testFromGlobals()
     {
-        $_SERVER = [
+        $server = [
             'PHP_SELF'             => '/blog/article.php',
             'GATEWAY_INTERFACE'    => 'CGI/1.1',
             'SERVER_ADDR'          => 'Server IP: 217.112.82.20',
@@ -376,21 +376,21 @@ class ServerRequestTest extends \PHPUnit_Framework_TestCase
             'REQUEST_URI'          => '/blog/article.php?id=10&user=foo',
         ];
 
-        $_COOKIE = [
+        $cookie = [
             'logged-in' => 'yes!',
         ];
 
-        $_POST = [
+        $post = [
             'name'  => 'Pesho',
             'email' => 'pesho@example.com',
         ];
 
-        $_GET = [
+        $get = [
             'id'   => 10,
             'user' => 'foo',
         ];
 
-        $_FILES = [
+        $files = [
             'file' => [
                 'name'     => 'MyFile.txt',
                 'type'     => 'text/plain',
@@ -400,15 +400,15 @@ class ServerRequestTest extends \PHPUnit_Framework_TestCase
             ],
         ];
 
-        $server = ServerRequest::fromGlobals();
+        $server = (new ServerRequestFactory())->createServerRequestFromGlobals($server, $cookie, $get, $post, $files);
 
         $this->assertEquals('POST', $server->getMethod());
         $this->assertEquals(['Host' => ['www.blakesimpson.co.uk']], $server->getHeaders());
         $this->assertEquals('', (string) $server->getBody());
         $this->assertEquals('1.0', $server->getProtocolVersion());
-        $this->assertEquals($_COOKIE, $server->getCookieParams());
-        $this->assertEquals($_POST, $server->getParsedBody());
-        $this->assertEquals($_GET, $server->getQueryParams());
+        $this->assertEquals($cookie, $server->getCookieParams());
+        $this->assertEquals($post, $server->getParsedBody());
+        $this->assertEquals($get, $server->getQueryParams());
 
         $this->assertEquals(
             new Uri('http://www.blakesimpson.co.uk/blog/article.php?id=10&user=foo'),

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -262,7 +262,9 @@ class ServerRequestTest extends \PHPUnit_Framework_TestCase
      */
     public function testNormalizeFiles($files, $expected)
     {
-        $result = ServerRequestFactory::normalizeFiles($files);
+        $result = (new ServerRequestFactory())
+            ->createServerRequestFromGlobals([], [], [], [], $files)
+            ->getUploadedFiles();
 
         $this->assertEquals($expected, $result);
     }
@@ -271,7 +273,7 @@ class ServerRequestTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('InvalidArgumentException', 'Invalid value in files specification');
 
-        ServerRequestFactory::normalizeFiles(['test' => 'something']);
+        (new ServerRequestFactory())->createServerRequestFromGlobals([], [], [], [], ['test' => 'something']);
     }
 
     public function dataGetUriFromGlobals()

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -263,7 +263,7 @@ class ServerRequestTest extends \PHPUnit_Framework_TestCase
     public function testNormalizeFiles($files, $expected)
     {
         $result = (new ServerRequestFactory())
-            ->createServerRequestFromGlobals([], [], [], [], $files)
+            ->createServerRequestFromArrays(['REQUEST_METHOD' => 'POST'], [], [], [], $files)
             ->getUploadedFiles();
 
         $this->assertEquals($expected, $result);
@@ -273,7 +273,7 @@ class ServerRequestTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('InvalidArgumentException', 'Invalid value in files specification');
 
-        (new ServerRequestFactory())->createServerRequestFromGlobals([], [], [], [], ['test' => 'something']);
+        (new ServerRequestFactory())->createServerRequestFromArrays(['REQUEST_METHOD' => 'POST'], [], [], [], ['test' => 'something']);
     }
 
     public function dataGetUriFromGlobals()
@@ -402,7 +402,7 @@ class ServerRequestTest extends \PHPUnit_Framework_TestCase
             ],
         ];
 
-        $server = (new ServerRequestFactory())->createServerRequestFromGlobals($server, $cookie, $get, $post, $files);
+        $server = (new ServerRequestFactory())->createServerRequestFromArrays($server, $cookie, $get, $post, $files);
 
         $this->assertEquals('POST', $server->getMethod());
         $this->assertEquals(['Host' => ['www.blakesimpson.co.uk']], $server->getHeaders());

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -263,7 +263,7 @@ class ServerRequestTest extends \PHPUnit_Framework_TestCase
     public function testNormalizeFiles($files, $expected)
     {
         $result = (new ServerRequestFactory())
-            ->createServerRequestFromArrays(['REQUEST_METHOD' => 'POST'], [], [], [], $files)
+            ->createServerRequestFromArrays(['REQUEST_METHOD' => 'POST'], [], [], [], [], $files)
             ->getUploadedFiles();
 
         $this->assertEquals($expected, $result);
@@ -273,7 +273,7 @@ class ServerRequestTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('InvalidArgumentException', 'Invalid value in files specification');
 
-        (new ServerRequestFactory())->createServerRequestFromArrays(['REQUEST_METHOD' => 'POST'], [], [], [], ['test' => 'something']);
+        (new ServerRequestFactory())->createServerRequestFromArrays(['REQUEST_METHOD' => 'POST'], [], [], [], [], ['test' => 'something']);
     }
 
     public function dataGetUriFromGlobals()
@@ -402,7 +402,7 @@ class ServerRequestTest extends \PHPUnit_Framework_TestCase
             ],
         ];
 
-        $server = (new ServerRequestFactory())->createServerRequestFromArrays($server, $cookie, $get, $post, $files);
+        $server = (new ServerRequestFactory())->createServerRequestFromArrays($server, [], $cookie, $get, $post, $files);
 
         $this->assertEquals('POST', $server->getMethod());
         $this->assertEquals(['Host' => ['www.blakesimpson.co.uk']], $server->getHeaders());


### PR DESCRIPTION
**WORK IN PROGRESS, DO NOT MERGE.**

First and foremost: this changes the public API for ServerRequest, BC breaks need to be documented. (Or not, seeing how we are at a version below 1.0.0.)

This implements the changes from https://github.com/Nyholm/psr7/issues/3#issuecomment-292812159 but should be discussed further before merge.

1. `getUriFromGlobals` has been renamed `createUriFromArray` and has been moved from ServerRequest to UriFactory.
   
   The signature has been changed to accept a single `$_SERVER`-structure as argument, instead of the method depending directly on the global `$_SERVER` variable.
2. `fromGlobals` has been renamed `createServerRequestFromGlobals` and has been moved from ServerRequest to ServerRequestFactory.
   
   The signature has been changed to accept 5 separate array structures matching the different global variables.
3. `normalizeFiles`, `createUploadedFileFromSpec`, and `normalizeNestedFileSpec` have been moved from ServerRequest to ServerRequestFactory. This is probably not the perfect place for them either, but gets them out of ServerRequest.
4. Return type hinting has been added to the factories.

`createUriFromArray` sets no default scheme value, but [http-interop/http-factory-tests](https://github.com/http-interop/http-factory-tests) expects ServerRequests to default to `http` through the factory. I made `createServerRequestFromGlobals` follow the factory expectation and added the default scheme there as well. This is a change from the old `fromGlobals`. But I am not sure if it is a good idea or not. Is there a use-case for creating a ServerRequest without a scheme?

The factory interface’s `createServerRequestFromArray` and our `createServerRequestFromGlobals` differ also on their requirement for a method. PSR-17 has us throw an InvalidArgumentException when the method can’t be found in the array, while `createServerRequestFromGlobals` defaults to `GET`. Should we follow the factory expectation here as well?

If we are following the factory expectation on both counts, it might be best to have `createServerRequestFromGlobals` go through `createServerRequestFromArray` first. Then adding the other globals to the created ServerRequest.

What would people expect to happen?

Finally: why is `normalizeFiles` public? Do we mean to support its API during future updates? If not, it should really be marked private.