### PR TITLE
Assign return value for getServerParams in factory

### DIFF
--- a/src/Factory/ServerRequestFactory.php
+++ b/src/Factory/ServerRequestFactory.php
@@ -26,7 +26,11 @@ class ServerRequestFactory implements ServerRequestFactoryInterface
     {
         return new ServerRequest(
             $this->getMethodFromEnvironment($server),
-            $this->getUriFromEnvironmentWithHTTP($server)
+            $this->getUriFromEnvironmentWithHTTP($server),
+            [],
+            null,
+            '1.1',
+            $server
         );
     }
 


### PR DESCRIPTION
The return value for getServerParams cannot be set after a ServerRequest instance is created. Make sure we can assign it through the factory.

I think this is worth it for the current ServerRequestFactory implementation. Though this might soon change with the current discussion that is going on. Therefor I didn’t want to commit this to master just yet and have here for review first.