### PR TITLE
Support using numeric headers

### DIFF
--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -211,7 +211,7 @@ trait MessageTrait
      */
     private function trimHeaderValues(array $values): array
     {
-        return array_map(function ($value) {
+        return array_map(function (string $value) {
             return trim($value, " \t");
         }, $values);
     }

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -165,6 +165,15 @@ class RequestTest extends TestCase
         $this->assertEquals('zoobar, foobar, zoobar', $r->getHeaderLine('zoo'));
     }
 
+    public function testSupportNumericHeaders()
+    {
+        $r = new Request('GET', '', [
+            'Content-Length' => 200,
+        ]);
+        $this->assertSame(['Content-Length' => ['200']], $r->getHeaders());
+        $this->assertSame('200', $r->getHeaderLine('Content-Length'));
+    }
+
     public function testAddsPortToHeader()
     {
         $r = new Request('GET', 'http://foo.com:8124/bar');


### PR DESCRIPTION
Support using numeric header values without having type errors. An example use case would be the usage of the `Content-Length` header, which might be set with the result of a call to `strlen`.

In fact, this is the case that caught my attention, by using the latest release of the [HWIOAuthBundle](https://github.com/hwi/HWIOAuthBundle). They [use `strlen` to set the `Content-Length` header](https://github.com/hwi/HWIOAuthBundle/blob/a45c54aed8acd2da032e7e03ae53f7e44d2a384e/OAuth/ResourceOwner/AbstractResourceOwner.php#L253) when building the request headers.

