### PR TITLE
Remove check for empty header string value

### DIFF
--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -85,7 +85,7 @@ trait MessageTrait
         }
 
         foreach ($value as $v) {
-            if (!is_string($v) || '' === trim($v)) {
+            if (!is_string($v)) {
                 throw new \InvalidArgumentException('Header values must be non-empty strings');
             }
         }
@@ -118,7 +118,7 @@ trait MessageTrait
         }
 
         foreach ($value as $v) {
-            if (!is_string($v) || '' === trim($v)) {
+            if (!is_string($v)) {
                 throw new \InvalidArgumentException('Header values must be non-empty strings');
             }
         }


### PR DESCRIPTION
I was using Buzz when I got an exception about empty header value.  
When I tried to use Zend Diactoros instead of this library it worked as expected.

If you'r interested I can put together a better fix that dose the validating more like it's done in [Zend Diactoros](https://github.com/zendframework/zend-diactoros/blob/master/src/HeaderSecurity.php#L96-L120)