### PR TITLE
Rephrase exception messages related to non empty header values

### DIFF
--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -77,16 +77,16 @@ trait MessageTrait
         if (!is_array($value)) {
             $value = [$value];
         } elseif (empty($value)) {
-            throw new \InvalidArgumentException('Header values must be non-empty strings');
+            throw new \InvalidArgumentException('Header values must be strings');
         }
 
         if (!is_string($header) || empty($header)) {
-            throw new \InvalidArgumentException('Header name must be non-empty strings');
+            throw new \InvalidArgumentException('Header name must be strings');
         }
 
         foreach ($value as $v) {
             if (!is_string($v)) {
-                throw new \InvalidArgumentException('Header values must be non-empty strings');
+                throw new \InvalidArgumentException('Header values must be strings');
             }
         }
 
@@ -110,16 +110,16 @@ trait MessageTrait
         } elseif (!empty($value)) {
             $value = array_values($value);
         } else {
-            throw new \InvalidArgumentException('Header values must be non-empty strings');
+            throw new \InvalidArgumentException('Header values must be strings');
         }
 
         if (!is_string($header) || empty($header)) {
-            throw new \InvalidArgumentException('Header name must be non-empty strings');
+            throw new \InvalidArgumentException('Header name must be strings');
         }
 
         foreach ($value as $v) {
             if (!is_string($v)) {
-                throw new \InvalidArgumentException('Header values must be non-empty strings');
+                throw new \InvalidArgumentException('Header values must be strings');
             }
         }
 


### PR DESCRIPTION
It looks like the [RFC-7230](https://tools.ietf.org/html/rfc7230#section-3.2) require header-value to be at least 1 charecter long. But I might be wrong.

What I can find most clients/librarys allow sending of empty header values

 - curl allow you to send empty headers
 - Firefox allows it for xhr/fetch with the motivation `We need it to be compliant with the XHR spec: "The empty string is legal and represents the empty header value."`
 - From the firefox thread it seams like Chrome also support sending and reciving empty header values
 - Guzzle support sending empty header-value https://github.com/guzzle/guzzle/pull/1915