### PR TITLE
Duplicated logic to avoid creating new instance of StreamFactory

### DIFF
--- a/src/Factory/Psr17Factory.php
+++ b/src/Factory/Psr17Factory.php
@@ -46,12 +46,12 @@ final class Psr17Factory implements RequestFactoryInterface, ResponseFactoryInte
 
     public function createStreamFromFile(string $filename, string $mode = 'r'): StreamInterface
     {
-        return Stream::createFromResource(fopen($filename, $mode));
+        return Stream::create(fopen($filename, $mode));
     }
 
     public function createStreamFromResource($resource): StreamInterface
     {
-        return Stream::createFromResource($resource);
+        return Stream::create($resource);
     }
 
     public function createUploadedFile(StreamInterface $stream, int $size = null, int $error = \UPLOAD_ERR_OK, string $clientFilename = null, string $clientMediaType = null): UploadedFileInterface

--- a/src/Factory/StreamFactory.php
+++ b/src/Factory/StreamFactory.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Nyholm\Psr7\Factory;
 
 use Nyholm\Psr7\Stream;
-use Psr\Http\Message\StreamInterface;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
@@ -14,14 +13,6 @@ final class StreamFactory implements \Http\Message\StreamFactory
 {
     public function createStream($body = null)
     {
-        if ($body instanceof StreamInterface) {
-            return $body;
-        }
-
-        if ('resource' === gettype($body)) {
-            return Stream::createFromResource($body);
-        }
-
         return Stream::create(null === $body ? '' : $body);
     }
 }

--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Nyholm\Psr7;
 
-use Nyholm\Psr7\Factory\StreamFactory;
 use Psr\Http\Message\StreamInterface;
 
 /**
@@ -115,7 +114,7 @@ trait MessageTrait
     public function getBody(): StreamInterface
     {
         if (!$this->stream) {
-            $this->stream = (new StreamFactory())->createStream('');
+            $this->stream = Stream::create('');
         }
 
         return $this->stream;

--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -193,4 +193,17 @@ trait MessageTrait
             return trim($value, " \t");
         }, $values);
     }
+
+    private function createStream($body = null): StreamInterface
+    {
+        if ($body instanceof StreamInterface) {
+            return $body;
+        }
+
+        if ('resource' === gettype($body)) {
+            return Stream::createFromResource($body);
+        }
+
+        return Stream::create(null === $body ? '' : $body);
+    }
 }

--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -193,17 +193,4 @@ trait MessageTrait
             return trim($value, " \t");
         }, $values);
     }
-
-    private function createStream($body = null): StreamInterface
-    {
-        if ($body instanceof StreamInterface) {
-            return $body;
-        }
-
-        if ('resource' === gettype($body)) {
-            return Stream::createFromResource($body);
-        }
-
-        return Stream::create(null === $body ? '' : $body);
-    }
 }

--- a/src/Request.php
+++ b/src/Request.php
@@ -39,7 +39,7 @@ final class Request implements RequestInterface
         }
 
         if ('' !== $body && null !== $body) {
-            $this->stream = $this->createStream($body);
+            $this->stream = Stream::create($body);
         }
     }
 }

--- a/src/Request.php
+++ b/src/Request.php
@@ -40,7 +40,7 @@ final class Request implements RequestInterface
         }
 
         if ('' !== $body && null !== $body) {
-            $this->stream = (new StreamFactory())->createStream($body);
+            $this->stream = $this->createStream($body);
         }
     }
 }

--- a/src/Request.php
+++ b/src/Request.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Nyholm\Psr7;
 
-use Nyholm\Psr7\Factory\StreamFactory;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;

--- a/src/Response.php
+++ b/src/Response.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Nyholm\Psr7;
 
-use Nyholm\Psr7\Factory\StreamFactory;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 

--- a/src/Response.php
+++ b/src/Response.php
@@ -42,7 +42,7 @@ final class Response implements ResponseInterface
         $this->statusCode = (int) $status;
 
         if ('' !== $body && null !== $body) {
-            $this->stream = $this->createStream($body);
+            $this->stream = Stream::create($body);
         }
 
         $this->setHeaders($headers);

--- a/src/Response.php
+++ b/src/Response.php
@@ -43,7 +43,7 @@ final class Response implements ResponseInterface
         $this->statusCode = (int) $status;
 
         if ('' !== $body && null !== $body) {
-            $this->stream = (new StreamFactory())->createStream($body);
+            $this->stream = $this->createStream($body);
         }
 
         $this->setHeaders($headers);

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Nyholm\Psr7;
 
-use Nyholm\Psr7\Factory\StreamFactory;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UploadedFileInterface;

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -62,7 +62,7 @@ final class ServerRequest implements ServerRequestInterface
         }
 
         if ('' !== $body && null !== $body) {
-            $this->stream = $this->createStream($body);
+            $this->stream = Stream::create($body);
         }
     }
 

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -63,7 +63,7 @@ final class ServerRequest implements ServerRequestInterface
         }
 
         if ('' !== $body && null !== $body) {
-            $this->stream = (new StreamFactory())->createStream($body);
+            $this->stream = $this->createStream($body);
         }
     }
 

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -86,7 +86,7 @@ final class Stream implements StreamInterface
         }
 
         if ('resource' === gettype($body)) {
-            return Stream::createFromResource($body);
+            return self::createFromResource($body);
         }
 
         if (is_string($body)) {

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -77,7 +77,7 @@ final class Stream implements StreamInterface
      *
      * @return StreamInterface
      *
-     * @throws \InvalidArgumentException If the stream body is invalid.
+     * @throws \InvalidArgumentException
      */
     public static function create($body = ''): StreamInterface
     {
@@ -97,7 +97,7 @@ final class Stream implements StreamInterface
             return $stream;
         }
 
-        throw new \InvalidArgumentException('Body must be a string, resource or StreamInterface.');
+        throw new \InvalidArgumentException('First argument to Stream::create() must be a string, resource or StreamInterface.');
     }
 
     /**

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -81,12 +81,12 @@ final class Stream implements StreamInterface
      */
     public static function create($body = ''): StreamInterface
     {
-        if ($body instanceof StreamInterface) {
-            return $body;
-        }
-
         if ('resource' === gettype($body)) {
             return self::createFromResource($body);
+        }
+
+        if ($body instanceof StreamInterface) {
+            return $body;
         }
 
         if (is_string($body)) {

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -53,7 +53,7 @@ final class Stream implements StreamInterface
     /**
      * @param resource $resource
      */
-    public static function createFromResource($resource): self
+    private static function createFromResource($resource): self
     {
         if (!is_resource($resource)) {
             throw new \InvalidArgumentException('Stream must be a resource');
@@ -70,13 +70,34 @@ final class Stream implements StreamInterface
         return $obj;
     }
 
-    public static function create(string $content): self
+    /**
+     * Creates a new PSR-7 stream.
+     *
+     * @param string|resource|StreamInterface $body
+     *
+     * @return StreamInterface
+     *
+     * @throws \InvalidArgumentException If the stream body is invalid.
+     */
+    public static function create($body = ''): StreamInterface
     {
-        $resource = fopen('php://temp', 'rw+');
-        $stream = self::createFromResource($resource);
-        $stream->write($content);
+        if ($body instanceof StreamInterface) {
+            return $body;
+        }
 
-        return $stream;
+        if ('resource' === gettype($body)) {
+            return Stream::createFromResource($body);
+        }
+
+        if (is_string($body)) {
+            $resource = fopen('php://temp', 'rw+');
+            $stream = self::createFromResource($resource);
+            $stream->write($body);
+
+            return $stream;
+        }
+
+        throw new \InvalidArgumentException('Body must be a string, resource or StreamInterface.');
     }
 
     /**

--- a/src/UploadedFile.php
+++ b/src/UploadedFile.php
@@ -73,7 +73,7 @@ final class UploadedFile implements UploadedFileInterface
         if (is_string($streamOrFile)) {
             $this->file = $streamOrFile;
         } elseif (is_resource($streamOrFile)) {
-            $this->stream = Stream::createFromResource($streamOrFile);
+            $this->stream = Stream::create($streamOrFile);
         } elseif ($streamOrFile instanceof StreamInterface) {
             $this->stream = $streamOrFile;
         } else {
@@ -163,7 +163,7 @@ final class UploadedFile implements UploadedFileInterface
 
         $resource = fopen($this->file, 'r');
 
-        return Stream::createFromResource($resource);
+        return Stream::create($resource);
     }
 
     public function moveTo($targetPath): void
@@ -183,7 +183,7 @@ final class UploadedFile implements UploadedFileInterface
             if ($stream->isSeekable()) {
                 $stream->rewind();
             }
-            $this->copyToStream($stream, Stream::createFromResource(fopen($targetPath, 'w')));
+            $this->copyToStream($stream, Stream::create(fopen($targetPath, 'w')));
             $this->moved = true;
         }
 

--- a/tests/Integration/StreamTest.php
+++ b/tests/Integration/StreamTest.php
@@ -9,6 +9,6 @@ class StreamTest extends StreamIntegrationTest
 {
     public function createStream($data)
     {
-        return Stream::createFromResource($data);
+        return Stream::create($data);
     }
 }

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -14,7 +14,7 @@ class StreamTest extends TestCase
     {
         $handle = fopen('php://temp', 'r+');
         fwrite($handle, 'data');
-        $stream = Stream::createFromResource($handle);
+        $stream = Stream::create($handle);
         $this->assertTrue($stream->isReadable());
         $this->assertTrue($stream->isWritable());
         $this->assertTrue($stream->isSeekable());
@@ -28,7 +28,7 @@ class StreamTest extends TestCase
     public function testStreamClosesHandleOnDestruct()
     {
         $handle = fopen('php://temp', 'r');
-        $stream = Stream::createFromResource($handle);
+        $stream = Stream::create($handle);
         unset($stream);
         $this->assertFalse(is_resource($handle));
     }
@@ -37,7 +37,7 @@ class StreamTest extends TestCase
     {
         $handle = fopen('php://temp', 'w+');
         fwrite($handle, 'data');
-        $stream = Stream::createFromResource($handle);
+        $stream = Stream::create($handle);
         $this->assertEquals('data', (string) $stream);
         $this->assertEquals('data', (string) $stream);
         $stream->close();
@@ -47,7 +47,7 @@ class StreamTest extends TestCase
     {
         $handle = fopen('php://temp', 'w+');
         fwrite($handle, 'data');
-        $stream = Stream::createFromResource($handle);
+        $stream = Stream::create($handle);
         $this->assertEquals('', $stream->getContents());
         $stream->seek(0);
         $this->assertEquals('data', $stream->getContents());
@@ -58,7 +58,7 @@ class StreamTest extends TestCase
     {
         $handle = fopen('php://temp', 'w+');
         fwrite($handle, 'data');
-        $stream = Stream::createFromResource($handle);
+        $stream = Stream::create($handle);
         $this->assertFalse($stream->eof());
         $stream->read(4);
         $this->assertTrue($stream->eof());
@@ -69,7 +69,7 @@ class StreamTest extends TestCase
     {
         $size = filesize(__FILE__);
         $handle = fopen(__FILE__, 'r');
-        $stream = Stream::createFromResource($handle);
+        $stream = Stream::create($handle);
         $this->assertEquals($size, $stream->getSize());
         // Load from cache
         $this->assertEquals($size, $stream->getSize());
@@ -80,7 +80,7 @@ class StreamTest extends TestCase
     {
         $h = fopen('php://temp', 'w+');
         $this->assertEquals(3, fwrite($h, 'foo'));
-        $stream = Stream::createFromResource($h);
+        $stream = Stream::create($h);
         $this->assertEquals(3, $stream->getSize());
         $this->assertEquals(4, $stream->write('test'));
         $this->assertEquals(7, $stream->getSize());
@@ -91,7 +91,7 @@ class StreamTest extends TestCase
     public function testProvidesStreamPosition()
     {
         $handle = fopen('php://temp', 'w+');
-        $stream = Stream::createFromResource($handle);
+        $stream = Stream::create($handle);
         $this->assertEquals(0, $stream->tell());
         $stream->write('foo');
         $this->assertEquals(3, $stream->tell());
@@ -104,7 +104,7 @@ class StreamTest extends TestCase
     public function testCanDetachStream()
     {
         $r = fopen('php://temp', 'w+');
-        $stream = Stream::createFromResource($r);
+        $stream = Stream::create($r);
         $stream->write('foo');
         $this->assertTrue($stream->isReadable());
         $this->assertSame($r, $stream->detach());
@@ -150,7 +150,7 @@ class StreamTest extends TestCase
     public function testCloseClearProperties()
     {
         $handle = fopen('php://temp', 'r+');
-        $stream = Stream::createFromResource($handle);
+        $stream = Stream::create($handle);
         $stream->close();
 
         $this->assertFalse($stream->isSeekable());


### PR DESCRIPTION
Im not sure what to do here. Is this a good solution? 

The logic is copied from `StreamFactory`. 
The alternative would be to create a new public method on `Stream` and **move** the code from `StreamFactory`. 