### PR TITLE
Pin specific functions to root namespace for optimisation

### DIFF
--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -90,7 +90,7 @@ trait MessageTrait
 
     public function withAddedHeader($header, $value): self
     {
-        if (!is_string($header) || '' === $header) {
+        if (!\is_string($header) || '' === $header) {
             throw new \InvalidArgumentException('Header name must be an RFC 7230 compatible string.');
         }
 
@@ -170,7 +170,7 @@ trait MessageTrait
      */
     private function validateAndTrimHeader($header, $values): array
     {
-        if (!is_array($values)) {
+        if (!\is_array($values)) {
             $values = [$values];
         } elseif (empty($values)) {
             throw new \InvalidArgumentException('Header values must be a string or an array of strings, empty array given.');
@@ -179,14 +179,14 @@ trait MessageTrait
             $values = array_values($values);
         }
 
-        if (!is_string($header) || 1 !== preg_match("@^[!#$%&'*+.^_`|~0-9A-Za-z-]+$@", $header)) {
+        if (!\is_string($header) || 1 !== preg_match("@^[!#$%&'*+.^_`|~0-9A-Za-z-]+$@", $header)) {
             throw new \InvalidArgumentException('Header name must be an RFC 7230 compatible string.');
         }
 
         foreach ($values as &$v) {
             if (is_numeric($v)) {
                 $v = (string) $v;
-            } elseif (!is_string($v) || 1 !== preg_match("@^[ \t\x21-\x7E\x80-\xFF]*$@", $v)) {
+            } elseif (!\is_string($v) || 1 !== preg_match("@^[ \t\x21-\x7E\x80-\xFF]*$@", $v)) {
                 throw new \InvalidArgumentException('Header values must be RFC 7230 compatible strings.');
             }
         }

--- a/src/RequestTrait.php
+++ b/src/RequestTrait.php
@@ -59,7 +59,7 @@ trait RequestTrait
 
     public function withMethod($method): self
     {
-        if (!is_string($method)) {
+        if (!\is_string($method)) {
             throw new \InvalidArgumentException('Method must be a string');
         }
 

--- a/src/Response.php
+++ b/src/Response.php
@@ -66,7 +66,7 @@ final class Response implements ResponseInterface
 
     public function withStatus($code, $reasonPhrase = ''): self
     {
-        if (!is_int($code) && !is_string($code)) {
+        if (!\is_int($code) && !\is_string($code)) {
             throw new \InvalidArgumentException('Status code has to be an integer');
         }
 

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -115,7 +115,7 @@ final class ServerRequest implements ServerRequestInterface
 
     public function withParsedBody($data)
     {
-        if (!is_array($data) && !is_object($data) && null !== $data) {
+        if (!\is_array($data) && !\is_object($data) && null !== $data) {
             throw new \InvalidArgumentException('First parameter to withParsedBody MUST be object, array or null');
         }
 

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -66,13 +66,13 @@ final class Stream implements StreamInterface
             return $body;
         }
 
-        if (is_string($body)) {
+        if (\is_string($body)) {
             $resource = fopen('php://temp', 'rw+');
             fwrite($resource, $body);
             $body = $resource;
         }
 
-        if ('resource' === gettype($body)) {
+        if ('resource' === \gettype($body)) {
             $obj = new self();
             $obj->stream = $body;
             $meta = stream_get_meta_data($obj->stream);
@@ -111,7 +111,7 @@ final class Stream implements StreamInterface
     public function close(): void
     {
         if (isset($this->stream)) {
-            if (is_resource($this->stream)) {
+            if (\is_resource($this->stream)) {
                 fclose($this->stream);
             }
             $this->detach();

--- a/src/UploadedFile.php
+++ b/src/UploadedFile.php
@@ -68,9 +68,9 @@ final class UploadedFile implements UploadedFileInterface
      */
     private function setStreamOrFile($streamOrFile): void
     {
-        if (is_string($streamOrFile)) {
+        if (\is_string($streamOrFile)) {
             $this->file = $streamOrFile;
-        } elseif (is_resource($streamOrFile)) {
+        } elseif (\is_resource($streamOrFile)) {
             $this->stream = Stream::create($streamOrFile);
         } elseif ($streamOrFile instanceof StreamInterface) {
             $this->stream = $streamOrFile;
@@ -81,11 +81,11 @@ final class UploadedFile implements UploadedFileInterface
 
     private function setError($error): void
     {
-        if (false === is_int($error)) {
+        if (false === \is_int($error)) {
             throw new \InvalidArgumentException('Upload file error status must be an integer');
         }
 
-        if (false === in_array($error, self::$errors)) {
+        if (false === \in_array($error, self::$errors)) {
             throw new \InvalidArgumentException('Invalid error status for UploadedFile');
         }
 
@@ -94,7 +94,7 @@ final class UploadedFile implements UploadedFileInterface
 
     private function setSize($size): void
     {
-        if (false === is_int($size)) {
+        if (false === \is_int($size)) {
             throw new \InvalidArgumentException('Upload file size must be an integer');
         }
 
@@ -103,12 +103,12 @@ final class UploadedFile implements UploadedFileInterface
 
     private function isStringOrNull($param): bool
     {
-        return in_array(gettype($param), ['string', 'NULL']);
+        return \in_array(\gettype($param), ['string', 'NULL']);
     }
 
     private function isStringNotEmpty($param): bool
     {
-        return is_string($param) && false === empty($param);
+        return \is_string($param) && false === empty($param);
     }
 
     private function setClientFilename($clientFilename): void
@@ -236,7 +236,7 @@ final class UploadedFile implements UploadedFileInterface
         $bytes = 0;
         while (!$source->eof()) {
             $buf = $source->read($maxLen - $bytes);
-            if (!($len = strlen($buf))) {
+            if (!($len = \strlen($buf))) {
                 break;
             }
             $bytes += $len;

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -274,7 +274,7 @@ final class Uri implements UriInterface
 
     private function filterScheme($scheme): string
     {
-        if (!is_string($scheme)) {
+        if (!\is_string($scheme)) {
             throw new \InvalidArgumentException('Scheme must be a string');
         }
 
@@ -283,7 +283,7 @@ final class Uri implements UriInterface
 
     private function filterHost($host): string
     {
-        if (!is_string($host)) {
+        if (!\is_string($host)) {
             throw new \InvalidArgumentException('Host must be a string');
         }
 
@@ -306,7 +306,7 @@ final class Uri implements UriInterface
 
     private function filterPath($path): string
     {
-        if (!is_string($path)) {
+        if (!\is_string($path)) {
             throw new \InvalidArgumentException('Path must be a string');
         }
 
@@ -315,7 +315,7 @@ final class Uri implements UriInterface
 
     private function filterQueryAndFragment($str): string
     {
-        if (!is_string($str)) {
+        if (!\is_string($str)) {
             throw new \InvalidArgumentException('Query and fragment must be a string');
         }
 


### PR DESCRIPTION
Further change coming out of #71, this specifies certain functions as coming from the root namespace.

Only functions on [this list of optimised functions](https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/b38da665fb73a25cdbc8311b439b7298fb50911c/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php#L347-L394) have been prefixed.