### PR TITLE
Handle fopen failing in createStreamFromFile: throw a RuntimeException.

### DIFF
--- a/src/Factory/Psr17Factory.php
+++ b/src/Factory/Psr17Factory.php
@@ -30,7 +30,12 @@ final class Psr17Factory implements RequestFactoryInterface, ResponseFactoryInte
 
     public function createStreamFromFile(string $filename, string $mode = 'r'): StreamInterface
     {
-        return Stream::create(\fopen($filename, $mode));
+        $resource = @\fopen($filename, $mode);
+        if (false === $resource) {
+            throw new \RuntimeException('The file '.$filename.'cannot be opened.');
+        }
+
+        return Stream::create($resource);
     }
 
     public function createStreamFromResource($resource): StreamInterface


### PR DESCRIPTION
I noticed this because of Nyholm/psr7-server#20. It looked like we were assuming `fopen` to always succeed rather than checking, this would even leek the PHP E_WARNING to the end-user.

This PR will suppress the E_WARNING (even the PHP manual tells us we might want to do that) and explicitly check for failure. If the file couldn’t be opened, it throws a `RuntimeException` in accordance with the PSR-17 definition.