### PR TITLE
Differentiate faulty mode from other failures

### DIFF
--- a/src/Factory/Psr17Factory.php
+++ b/src/Factory/Psr17Factory.php
@@ -32,7 +32,11 @@ final class Psr17Factory implements RequestFactoryInterface, ResponseFactoryInte
     {
         $resource = @\fopen($filename, $mode);
         if (false === $resource) {
-            throw new \RuntimeException('The file '.$filename.'cannot be opened.');
+            if (0 === \strlen($mode) || false === \in_array($mode[0], ['r', 'w', 'a', 'x', 'c'])) {
+                throw new \InvalidArgumentException('The mode '.$mode.' is invalid.');
+            }
+
+            throw new \RuntimeException('The file '.$filename.' cannot be opened.');
         }
 
         return Stream::create($resource);


### PR DESCRIPTION
Check matches PHP’s own [fopen modes parser](https://github.com/php/php-src/blob/217159d57a083908823b6d9e356ccde14abf37dc/main/streams/plain_wrapper.c#L64).