### PR TITLE
Change minimal port number to 0 (unix socket)

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -278,8 +278,8 @@ final class Uri implements UriInterface
         }
 
         $port = (int) $port;
-        if (1 > $port || 0xffff < $port) {
-            throw new \InvalidArgumentException(\sprintf('Invalid port: %d. Must be between 1 and 65535', $port));
+        if (0 > $port || 0xffff < $port) {
+            throw new \InvalidArgumentException(\sprintf('Invalid port: %d. Must be between 0 and 65535', $port));
         }
 
         return self::isNonStandardPort($this->scheme, $port) ? $port : null;

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -113,17 +113,17 @@ class UriTest extends TestCase
     public function testPortMustBeValid()
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid port: 100000. Must be between 1 and 65535');
+        $this->expectExceptionMessage('Invalid port: 100000. Must be between 0 and 65535');
 
         (new Uri())->withPort(100000);
     }
 
-    public function testWithPortCannotBeZero()
+    public function testWithPortCannotBeNegative()
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid port: 0. Must be between 1 and 65535');
+        $this->expectExceptionMessage('Invalid port: -1. Must be between 0 and 65535');
 
-        (new Uri())->withPort(0);
+        (new Uri())->withPort(-1);
     }
 
     public function testParseUriPortCannotBeZero()


### PR DESCRIPTION
Listening on an unix socket reports port number 0, which is interpreted as an invalid argument.