### PR TITLE
fix-response-reasonphrase-created-by-factory-and-type-safety

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -45,12 +45,13 @@ final class Response implements ResponseInterface
         }
 
         $this->statusCode = $status;
-        $this->setHeaders($headers);
-        if (null === $reason && isset(self::PHRASES[$this->statusCode])) {
-            $this->reasonPhrase = self::PHRASES[$status];
-        } else {
-            $this->reasonPhrase = $reason;
+        $this->reasonPhrase = (string) $reason;
+
+        if ('' === $this->reasonPhrase && isset(self::PHRASES[$this->statusCode])) {
+            $this->reasonPhrase = self::PHRASES[$this->statusCode];
         }
+
+        $this->setHeaders($headers);
 
         $this->protocol = $version;
     }
@@ -77,11 +78,13 @@ final class Response implements ResponseInterface
         }
 
         $new = clone $this;
+
         $new->statusCode = $code;
-        if ((null === $reasonPhrase || '' === $reasonPhrase) && isset(self::PHRASES[$new->statusCode])) {
-            $reasonPhrase = self::PHRASES[$new->statusCode];
+        $new->reasonPhrase = (string) $reasonPhrase;
+
+        if ('' === $new->reasonPhrase && isset(self::PHRASES[$new->statusCode])) {
+            $new->reasonPhrase = self::PHRASES[$new->statusCode];
         }
-        $new->reasonPhrase = $reasonPhrase;
 
         return $new;
     }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Nyholm\Psr7;
 
+use Nyholm\Psr7\Factory\Psr17Factory;
 use Nyholm\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\StreamInterface;
@@ -251,5 +252,13 @@ class ResponseTest extends TestCase
         $this->assertSame(['OWS' => ['Foo']], $r->getHeaders());
         $this->assertSame('Foo', $r->getHeaderLine('OWS'));
         $this->assertSame(['Foo'], $r->getHeader('OWS'));
+    }
+
+    public function testCanConstructWithFactory()
+    {
+        $f = new Psr17Factory();
+        $r = $f->createResponse(200);
+        $this->assertSame(200, $r->getStatusCode());
+        $this->assertSame('OK', $r->getReasonPhrase());
     }
 }


### PR DESCRIPTION
I could not write a test, which shows the type conversion issue, cause the tests is not using strict, (if i change that i break other tests), but hopefully you get the point within #116 