### PR TITLE
Fix null reason phrase resulting from Response constructor

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -49,7 +49,7 @@ final class Response implements ResponseInterface
         if (null === $reason && isset(self::PHRASES[$this->statusCode])) {
             $this->reasonPhrase = self::PHRASES[$status];
         } else {
-            $this->reasonPhrase = $reason;
+            $this->reasonPhrase = $reason ?? '';
         }
 
         $this->protocol = $version;

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -30,6 +30,13 @@ class ResponseTest extends TestCase
         $this->assertSame('Not Found', $r->getReasonPhrase());
     }
 
+    public function testCanConstructWithUndefinedStatusCode()
+    {
+        $r = new Response(999);
+        $this->assertSame(999, $r->getStatusCode());
+        $this->assertSame('', $r->getReasonPhrase());
+    }
+
     public function testConstructorDoesNotReadStreamBody()
     {
         $body = $this->getMockBuilder(StreamInterface::class)->getMock();


### PR DESCRIPTION
This addresses [the issue noticed in the discussion around #117](https://github.com/Nyholm/psr7/pull/117#issuecomment-487383940). This is purely to fix that one bug, I have not tested other usage of `$reasonPhrase`, not do I make any steps on resolving the core discussion of #117 and #118.

We may need to revise our thinking around `$reasonPhrase` for a 2.0 release (if we want to strictly adhere to semver).