### PR TITLE
Fix checking for seekable stream resources

### DIFF
--- a/src/Stream.php
+++ b/src/Stream.php
@@ -76,7 +76,7 @@ final class Stream implements StreamInterface
             $new = new self();
             $new->stream = $body;
             $meta = \stream_get_meta_data($new->stream);
-            $new->seekable = $meta['seekable'];
+            $new->seekable = $meta['seekable'] && 0 === \fseek($new->stream, 0, \SEEK_CUR);
             $new->readable = isset(self::READ_WRITE_HASH['read'][$meta['mode']]);
             $new->writable = isset(self::READ_WRITE_HASH['write'][$meta['mode']]);
             $new->uri = $new->getMetadata('uri');

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -160,4 +160,34 @@ class StreamTest extends TestCase
         $this->assertNull($stream->getSize());
         $this->assertEmpty($stream->getMetadata());
     }
+
+    public function testUnseekableStreamWrapper()
+    {
+        stream_wrapper_register('nyholm-psr7-test', TestStreamWrapper::class);
+        $handle = fopen('nyholm-psr7-test://', 'r');
+        stream_wrapper_unregister('nyholm-psr7-test');
+
+        $stream = Stream::create($handle);
+        $this->assertFalse($stream->isSeekable());
+    }
+}
+
+class TestStreamWrapper
+{
+    public $context;
+
+    public function stream_open()
+    {
+        return true;
+    }
+
+    public function stream_seek(int $offset, int $whence = SEEK_SET)
+    {
+        return false;
+    }
+
+    public function stream_eof()
+    {
+        return true;
+    }
 }


### PR DESCRIPTION
Userland stream wrappers always return true for the "seekable" metadata, yet this can be wrong. Here is a more accurate check.