### PR TITLE
Added test to make sure we can create response with empty reason phrase

### DIFF
--- a/src/Factory/Psr17Factory.php
+++ b/src/Factory/Psr17Factory.php
@@ -20,6 +20,11 @@ final class Psr17Factory implements RequestFactoryInterface, ResponseFactoryInte
 
     public function createResponse(int $code = 200, string $reasonPhrase = ''): ResponseInterface
     {
+        if (2 > \func_num_args()) {
+            // This will make the Response class to use a custom reasonPhrase
+            $reasonPhrase = null;
+        }
+
         return new Response($code, [], null, '1.1', $reasonPhrase);
     }
 

--- a/tests/Factory/Psr17FactoryTest.php
+++ b/tests/Factory/Psr17FactoryTest.php
@@ -20,5 +20,19 @@ class Psr17FactoryTest extends TestCase
 
         $r = $factory->createResponse(200, 'Foo');
         $this->assertEquals('Foo', $r->getReasonPhrase());
+
+        /*
+         * Test for non-standard response codes
+         */
+        $r = $factory->createResponse(567);
+        $this->assertEquals('', $r->getReasonPhrase());
+
+        $r = $factory->createResponse(567, '');
+        $this->assertEquals(567, $r->getStatusCode());
+        $this->assertEquals('', $r->getReasonPhrase());
+
+        $r = $factory->createResponse(567, 'Foo');
+        $this->assertEquals(567, $r->getStatusCode());
+        $this->assertEquals('Foo', $r->getReasonPhrase());
     }
 }

--- a/tests/Factory/Psr17FactoryTest.php
+++ b/tests/Factory/Psr17FactoryTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Nyholm\Psr7\Factory;
+
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+
+class Psr17FactoryTest extends TestCase
+{
+    public function testCreateResponse()
+    {
+        $factory = new Psr17Factory();
+        $r = $factory->createResponse(200);
+        $this->assertEquals('OK', $r->getReasonPhrase());
+
+        $r = $factory->createResponse(200, '');
+        $this->assertEquals('', $r->getReasonPhrase());
+
+        $r = $factory->createResponse(200, 'Foo');
+        $this->assertEquals('Foo', $r->getReasonPhrase());
+    }
+}

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -37,6 +37,13 @@ class ResponseTest extends TestCase
         $this->assertSame('', $r->getReasonPhrase());
     }
 
+    public function testCanConstructWithStatusCodeAndEmptyReason()
+    {
+        $r = new Response(404, [], null, '1.1', '');
+        $this->assertSame(404, $r->getStatusCode());
+        $this->assertSame('', $r->getReasonPhrase());
+    }
+
     public function testConstructorDoesNotReadStreamBody()
     {
         $body = $this->getMockBuilder(StreamInterface::class)->getMock();
@@ -258,12 +265,5 @@ class ResponseTest extends TestCase
         $this->assertSame(['OWS' => ['Foo']], $r->getHeaders());
         $this->assertSame('Foo', $r->getHeaderLine('OWS'));
         $this->assertSame(['Foo'], $r->getHeader('OWS'));
-    }
-
-    public function testCanConstructWithStatusCodeAndEmptyReason()
-    {
-        $r = new Response(404, [], null, '1.1', '');
-        $this->assertSame(404, $r->getStatusCode());
-        $this->assertSame('', $r->getReasonPhrase());
     }
 }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -259,4 +259,11 @@ class ResponseTest extends TestCase
         $this->assertSame('Foo', $r->getHeaderLine('OWS'));
         $this->assertSame(['Foo'], $r->getHeader('OWS'));
     }
+
+    public function testCanConstructWithStatusCodeAndEmptyReason()
+    {
+        $r = new Response(404, [], null, '1.1', '');
+        $this->assertSame(404, $r->getStatusCode());
+        $this->assertSame('', $r->getReasonPhrase());
+    }
 }


### PR DESCRIPTION
Follow up form #118 


This PR also changes the behavior if you call `$psr17Factory->createResponse(200)`. 

Before we did not give any reason phrase, now we do. Is this a BC break? It is still fine according to PSR17. 