### PR TITLE
Fix for UTF-8 in hostname

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -54,7 +54,7 @@ final class Uri implements UriInterface
             // Apply parse_url parts to a URI.
             $this->scheme = isset($parts['scheme']) ? \strtolower($parts['scheme']) : '';
             $this->userInfo = $parts['user'] ?? '';
-            $this->host = isset($parts['host']) ? \strtolower($parts['host']) : '';
+            $this->host = isset($parts['host']) ? \preg_replace_callback('/([A-Z])/',static function($cap) { return strtolower($cap[0]); },$parts['host']) : '';
             $this->port = isset($parts['port']) ? $this->filterPort($parts['port']) : null;
             $this->path = isset($parts['path']) ? $this->filterPath($parts['path']) : '';
             $this->query = isset($parts['query']) ? $this->filterQueryAndFragment($parts['query']) : '';

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -15,7 +15,8 @@ use Psr\Http\Message\UriInterface;
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  * @author Martijn van der Ven <martijn@vanderven.se>
  */
-final class Uri implements UriInterface {
+final class Uri implements UriInterface
+{
     private const SCHEMES = ['http' => 80, 'https' => 443];
 
     private const CHAR_UNRESERVED = 'a-zA-Z0-9_\-\.~';
@@ -43,9 +44,10 @@ final class Uri implements UriInterface {
     /** @var string Uri fragment. */
     private $fragment = '';
 
-    public function __construct(string $uri = '') {
-        if('' !== $uri) {
-            if(false === $parts = \parse_url($uri)) {
+    public function __construct(string $uri = '')
+    {
+        if ('' !== $uri) {
+            if (false === $parts = \parse_url($uri)) {
                 throw new \InvalidArgumentException("Unable to parse URI: $uri");
             }
             // Apply parse_url parts to a URI.
@@ -56,7 +58,7 @@ final class Uri implements UriInterface {
             $this->path = isset($parts['path']) ? $this->filterPath($parts['path']) : '';
             $this->query = isset($parts['query']) ? $this->filterQueryAndFragment($parts['query']) : '';
             $this->fragment = isset($parts['fragment']) ? $this->filterQueryAndFragment($parts['fragment']) : '';
-            if(isset($parts['pass'])) {
+            if (isset($parts['pass'])) {
                 $this->userInfo .= ':' . $parts['pass'];
             }
         }
@@ -272,8 +274,8 @@ final class Uri implements UriInterface {
     {
         return \preg_replace_callback(
             '/([A-Z])/',
-            static function($cap) {
-                return strtolower($cap[0]);
+            static function ($cap) {
+                return \strtolower($cap[0]);
             },
             $host
         );

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -471,4 +471,13 @@ class UriTest extends TestCase
         $this->assertNotSame($uri, $uri->withQuery('q=abc'));
         $this->assertNotSame($uri, $uri->withFragment('test'));
     }
+    
+    public function testUtf8Host()
+    {
+        $uri = new Uri('http://ουτοπία.δπθ.gr/');
+        $this->assertSame('ουτοπία.δπθ.gr', $uri->getHost());
+        $new = $uri->withHost('程式设计.com');
+        $this->assertSame('程式设计.com', $new->getHost());
+    }
+
 }


### PR DESCRIPTION
This patch replaces using strtolower() on hostnames as this cant handle utf-8 characters, I have opted to do this with a regex to prevent adding mbstring as a dependancy