### PR TITLE
Use a Unicode safe version of strtolower for hostnames

### DIFF
--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -295,6 +295,23 @@ class UriTest extends TestCase
         $this->assertSame('//example.com', (string) $uri);
     }
 
+    public function testHostNormalizationLeavesUnicodeIntact()
+    {
+        $resetLocale = false;
+        if (\in_array($currentLocale = \setlocale(\LC_CTYPE, '0'), ['POSIX', 'C'])) {
+            $resetLocale = \setlocale(\LC_CTYPE, ['en_US.UTF-8', 'en_US.US-ASCII', 'en_US']);
+        }
+
+        $testDomain = 'παράδειγμα.δοκιμή';
+        $uri = (new Uri())->withHost($testDomain);
+        $this->assertSame($testDomain, $uri->getHost());
+        $this->assertSame('//' . $testDomain, (string) $uri);
+
+        if (false !== $resetLocale) {
+            \setlocale(\LC_CTYPE, $currentLocale);
+        }
+    }
+
     public function testPortIsNullIfStandardPortForScheme()
     {
         // HTTPS standard port


### PR DESCRIPTION
This was a bit of a head-scratcher. After a long back-and-forth with @cseufert in #131 this is my try at fixing it. I am not sure this is better or worse than what is proposed in #131. It is definitely more complex, and hopefully covers the issue in its entirety for a multitude of platforms.

In the first commit I introduce a way to test for this problem in PHPUnit. I am not sure this is the best way to do it. I try to change the locale to something else if it happens to be `C` or `POSIX`. But there is no sure way to know what it should be changed to. Some form of `en_US` sounded like it would be most likely to be available.

I am not sure I like this way of testing. I cannot guarantee that the CI testing runs on has some form of `en_US` available, so we may still accidentally break the function without noticing. Doing setup and teardown within the test method itself is also bad, especially since the teardown (resetting the locale to what it originally was) fails if any of the PHPUnit assertions fail.

An alternative would be to split locale aware tests off to their own PHPUnit TestCase and use actual `setUp` and `tearDown` fixtures.

In the second commit I introduce a safe version of `strtolower`. It will either temporarily put the locale to `C` or `POSIX`, or use a regular expression only targetting ASCII characters. For this I assume that switching the locale to run `strtolower` only once is faster than running regular expressions and multiple `strtolower` calls.

The regular expression loop is hopefully slightly more performant than the one suggested by @cseufert as well. Instead of running for every single capital letter, it runs once per string of ASCII characters. A mixed string like `eXaMpLe.CoM` will only call `strtolower` once as the entire string will be matched in one go.

A problem with having the regular expression fallback included in the same method is that it complicates unit testing. On a system where `setlocale` works, it will never reach the regular expression variant. One solution is to mock `setlocale`, but then we must call the function unqualified (without `\`) or rely on a PHP extension to replace internals. If anyone has any good ideas, I am all ears!