### PR TITLE
Fix bug with stream rewind in Stream::create

### DIFF
--- a/src/Stream.php
+++ b/src/Stream.php
@@ -76,7 +76,7 @@ final class Stream implements StreamInterface
             $new = new self();
             $new->stream = $body;
             $meta = \stream_get_meta_data($new->stream);
-            $new->seekable = $meta['seekable'] && 0 === \fseek($new->stream, 0, \SEEK_CUR);
+            $new->seekable = $meta['seekable'] && 0 === \fseek($new->stream, 0, \SEEK_SET);
             $new->readable = isset(self::READ_WRITE_HASH['read'][$meta['mode']]);
             $new->writable = isset(self::READ_WRITE_HASH['write'][$meta['mode']]);
             $new->uri = $new->getMetadata('uri');

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -48,8 +48,6 @@ class StreamTest extends TestCase
         $handle = fopen('php://temp', 'w+');
         fwrite($handle, 'data');
         $stream = Stream::create($handle);
-        $this->assertEquals('', $stream->getContents());
-        $stream->seek(0);
         $this->assertEquals('data', $stream->getContents());
         $this->assertEquals('', $stream->getContents());
     }


### PR DESCRIPTION
Your stream is left unrewinded after creation and it breaks compatibility with other PSR-7 libraries because they does not require manual stream rewind.
This looks like a bug, so I propose a fix.