### PR TITLE
Make __toString() compatible with throwing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
     "require-dev": {
         "phpunit/phpunit": "^7.5",
         "php-http/psr7-integration-tests": "^1.0",
-        "http-interop/http-factory-tests": "dev-master"
+        "http-interop/http-factory-tests": "dev-master",
+        "symfony/error-handler": "^4.4"
     },
     "provide": {
         "psr/http-message-implementation": "1.0",

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Nyholm\Psr7;
 
 use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Debug\ErrorHandler as SymfonyLegacyErrorHandler;
+use Symfony\Component\ErrorHandler\ErrorHandler as SymfonyErrorHandler;
 
 /**
  * @author Michael Dowling and contributors to guzzlehttp/psr7
@@ -93,7 +95,10 @@ final class Stream implements StreamInterface
         $this->close();
     }
 
-    public function __toString(): string
+    /**
+     * @return string
+     */
+    public function __toString()
     {
         try {
             if ($this->isSeekable()) {
@@ -101,7 +106,20 @@ final class Stream implements StreamInterface
             }
 
             return $this->getContents();
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
+            if (\PHP_VERSION_ID >= 70400) {
+                throw $e;
+            }
+
+            if (\is_array($errorHandler = \set_error_handler('var_dump'))) {
+                $errorHandler = $errorHandler[0] ?? null;
+            }
+            \restore_error_handler();
+
+            if ($e instanceof \Error || $errorHandler instanceof SymfonyErrorHandler || $errorHandler instanceof SymfonyLegacyErrorHandler) {
+                return \trigger_error((string) $e, \E_USER_ERROR);
+            }
+
             return '';
         }
     }

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -4,6 +4,7 @@ namespace Tests\Nyholm\Psr7;
 
 use Nyholm\Psr7\Stream;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\ErrorHandler\ErrorHandler as SymfonyErrorHandler;
 
 /**
  * @covers \Nyholm\Psr7\Stream
@@ -144,7 +145,21 @@ class StreamTest extends TestCase
         $throws(function ($stream) {
             $stream->getContents();
         });
-        $this->assertSame('', (string) $stream);
+        if (\PHP_VERSION_ID >= 70400) {
+            $throws(function ($stream) {
+                (string) $stream;
+            });
+        } else {
+            $this->assertSame('', (string) $stream);
+
+            SymfonyErrorHandler::register();
+            $throws(function ($stream) {
+                (string) $stream;
+            });
+            restore_error_handler();
+            restore_exception_handler();
+        }
+
         $stream->close();
     }
 


### PR DESCRIPTION
Fix #142

On PHP 7.4, `__toString()` can throw.
And before PHP  7.4, `__toString()` can throw also, when the Symfony ErrorHandler is used: https://github.com/symfony/symfony/blob/e46495499841f805ab1915643f763d736d24822e/src/Symfony/Component/ErrorHandler/ErrorHandler.php#L498-L503

This fixes tests meanwhile.