### PR TITLE
Removed PHP7 line

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ A super lightweight PSR-7 implementation. Very strict and very fast.
 | Description | Guzzle | Zend | Slim | Nyholm |
 | ---- | ------ | ---- | ---- | ------ |
 | Lines of code | 3 000 | 3 000 | 1 700 | 1 000 |
-| PHP7 | No | Yes | No | Yes |
 | PSR-7* | 66% | 100% | 75% | 100% |
 | PSR-17 | No | Yes | Yes | Yes |
 | HTTPlug | No | No | No | Yes |
@@ -30,16 +29,16 @@ A super lightweight PSR-7 implementation. Very strict and very fast.
 composer require nyholm/psr7
 ```
 
-If you are using Symfony Flex then you get all message factories registered as services. 
+If you are using Symfony Flex then you get all message factories registered as services.
 
 ## Usage
 
 The PSR-7 objects do not contain any other public methods than those defined in
-the [PSR-7 specification](https://www.php-fig.org/psr/psr-7/). 
+the [PSR-7 specification](https://www.php-fig.org/psr/psr-7/).
 
 ### Create objects
 
-Use the PSR-17 factory to create requests, streams, URIs etc.  
+Use the PSR-17 factory to create requests, streams, URIs etc.
 
 ```php
 $psr17Factory = new \Nyholm\Psr7\Factory\Psr17Factory();
@@ -49,8 +48,8 @@ $stream = $psr17Factory->createStream('foobar');
 
 ### Sending a request
 
-With [HTTPlug](http://httplug.io/) or any other PSR-18 (HTTP client) you may send 
-requests like: 
+With [HTTPlug](http://httplug.io/) or any other PSR-18 (HTTP client) you may send
+requests like:
 
 ```bash
 composer require kriswallsmith/buzz
@@ -66,7 +65,7 @@ $response = $psr18Client->sendRequest($request);
 
 ### Create server requests
 
-The [`nyholm/psr7-server`](https://github.com/Nyholm/psr7-server) package can be used 
+The [`nyholm/psr7-server`](https://github.com/Nyholm/psr7-server) package can be used
 to create server requests from PHP superglobals.
 
 ```bash
@@ -102,10 +101,10 @@ $response = $psr17Factory->createResponse(200)->withBody($responseBody);
 
 ## Our goal
 
-This package is currently maintained by [Tobias Nyholm](http://nyholm.se) and 
+This package is currently maintained by [Tobias Nyholm](http://nyholm.se) and
 [Martijn van der Ven](https://vanderven.se/martijn/). They have decided that the
-goal of this library should be to provide a super strict implementation of 
-[PSR-7](https://www.php-fig.org/psr/psr-7/) that is blazing fast. 
+goal of this library should be to provide a super strict implementation of
+[PSR-7](https://www.php-fig.org/psr/psr-7/) that is blazing fast.
 
 The package will never include any extra features nor helper methods. All our classes
-and functions exist because they are required to fulfill the PSR-7 specification. 
+and functions exist because they are required to fulfill the PSR-7 specification.


### PR DESCRIPTION
I've forgotten that "Can be used on PHP7" was a selling point.. It is quite out dated now though. 