### PR TITLE
Updated Zend to Laminas in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A super lightweight PSR-7 implementation. Very strict and very fast.
 
 | Description | Guzzle | Laminas | Slim | Nyholm |
 | ---- | ------ | ---- | ---- | ------ |
-| Lines of code | 3 000 | 3 000 | 1 700 | 1 000 |
+| Lines of code | 5 892 | 5 892 | 4 270 | 1 510 |
 | PSR-7* | 66% | 100% | 75% | 100% |
 | PSR-17 | No | Yes | Yes | Yes |
 | HTTPlug | No | No | No | Yes |

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 A super lightweight PSR-7 implementation. Very strict and very fast.
 
-| Description | Guzzle | Zend | Slim | Nyholm |
+| Description | Guzzle | Laminas | Slim | Nyholm |
 | ---- | ------ | ---- | ---- | ------ |
 | Lines of code | 3 000 | 3 000 | 1 700 | 1 000 |
 | PSR-7* | 66% | 100% | 75% | 100% |
@@ -88,15 +88,15 @@ $serverRequest = $creator->fromGlobals();
 ### Emitting a response
 
 ```bash
-composer require zendframework/zend-httphandlerrunner
+composer require laminas/laminas-httphandlerrunner
 ```
 
 ```php
 $psr17Factory = new \Nyholm\Psr7\Factory\Psr17Factory();
 
-$responseBody = $psr17Factory->createStream('Hello world');
-$response = $psr17Factory->createResponse(200)->withBody($responseBody);
-(new \Zend\HttpHandlerRunner\Emitter\SapiEmitter())->emit($response);
+$responseBody = $psr17Factory->createStream('Hello World!');
+$response = $psr17Factory->createResponse()->withBody($responseBody);
+(new Laminas\HttpHandlerRunner\Emitter\SapiEmitter())->emit($response);
 ```
 
 ## Our goal


### PR DESCRIPTION
Since Zend is no longer maintained, the README should be updated.
- [X] Changed Zend to Laminas in test cases. (*)
- [X] Changed Zend HttpHandlerRunner to the Laminas one.

>  *: Create a Pull Request to the [HTTP Client Benchmark also](https://github.com/Nyholm/http-client-benchmark), because it is probably outdated and isn't 100% accurate for the 'new' Laminas case.
> This Pull Request probably the same as #165, but I'll make a follow up in the above mentioned repository.
> Edit: the follow up in the benchmarks also ready to merge: [Test PSR-7 implementation #2](https://github.com/Nyholm/http-client-benchmark/pull/2)