### PR TITLE
Remove final keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 1.4.0
+
+### Removed
+
+The `final` keyword was replaced by `@final` annotation.
+
 ## 1.3.2
 
 ### Fixed

--- a/doc/final.md
+++ b/doc/final.md
@@ -1,0 +1,20 @@
+# Final classes
+
+The `final` keyword was removed in version 1.4.0. It was replaced by `@final` annotation.
+This was done due popular demand, not because it is a good technical reason to
+extend the classes.
+
+This document will show the correct way to work with PSR-7 classes. The "correct way"
+refers to best practices and good software design. I strongly believe that one should
+be aware of how a problem *should* be solved, however, it is not needed to always
+implement that solution.
+
+## Extending classes
+
+You should never extend the classes, you should rather use composition or implement
+the interface yourself.
+
+## Mocking classes
+
+The PSR-7 classes are all value objects and they can be used without mocking. If
+one really needs to create a special scenario, one cna mock the interface instead.

--- a/doc/final.md
+++ b/doc/final.md
@@ -17,4 +17,4 @@ the interface yourself.
 ## Mocking classes
 
 The PSR-7 classes are all value objects and they can be used without mocking. If
-one really needs to create a special scenario, one cna mock the interface instead.
+one really needs to create a special scenario, one can mock the interface instead.

--- a/doc/final.md
+++ b/doc/final.md
@@ -12,7 +12,7 @@ implement that solution.
 ## Extending classes
 
 You should never extend the classes, you should rather use composition or implement
-the interface yourself.
+the interface yourself. Please refer to the [decorator pattern](https://refactoring.guru/design-patterns/decorator).
 
 ## Mocking classes
 

--- a/src/Factory/HttplugFactory.php
+++ b/src/Factory/HttplugFactory.php
@@ -11,8 +11,10 @@ use Psr\Http\Message\UriInterface;
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  * @author Martijn van der Ven <martijn@vanderven.se>
+ *
+ * @final There is no situation where it is a good idea to extend this class.
  */
-final class HttplugFactory implements MessageFactory, StreamFactory, UriFactory
+class HttplugFactory implements MessageFactory, StreamFactory, UriFactory
 {
     public function createRequest($method, $uri, array $headers = [], $body = null, $protocolVersion = '1.1')
     {

--- a/src/Factory/HttplugFactory.php
+++ b/src/Factory/HttplugFactory.php
@@ -12,7 +12,7 @@ use Psr\Http\Message\UriInterface;
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  * @author Martijn van der Ven <martijn@vanderven.se>
  *
- * @final There is no situation where it is a good idea to extend this class.
+ * @final This class should never be extended. See https://github.com/Nyholm/psr7/blob/master/doc/final.md
  */
 class HttplugFactory implements MessageFactory, StreamFactory, UriFactory
 {

--- a/src/Factory/Psr17Factory.php
+++ b/src/Factory/Psr17Factory.php
@@ -11,7 +11,7 @@ use Psr\Http\Message\{RequestFactoryInterface, RequestInterface, ResponseFactory
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  * @author Martijn van der Ven <martijn@vanderven.se>
  *
- * @final There is no situation where it is a good idea to extend this class.
+ * @final This class should never be extended. See https://github.com/Nyholm/psr7/blob/master/doc/final.md
  */
 class Psr17Factory implements RequestFactoryInterface, ResponseFactoryInterface, ServerRequestFactoryInterface, StreamFactoryInterface, UploadedFileFactoryInterface, UriFactoryInterface
 {

--- a/src/Factory/Psr17Factory.php
+++ b/src/Factory/Psr17Factory.php
@@ -10,8 +10,10 @@ use Psr\Http\Message\{RequestFactoryInterface, RequestInterface, ResponseFactory
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  * @author Martijn van der Ven <martijn@vanderven.se>
+ *
+ * @final There is no situation where it is a good idea to extend this class.
  */
-final class Psr17Factory implements RequestFactoryInterface, ResponseFactoryInterface, ServerRequestFactoryInterface, StreamFactoryInterface, UploadedFileFactoryInterface, UriFactoryInterface
+class Psr17Factory implements RequestFactoryInterface, ResponseFactoryInterface, ServerRequestFactoryInterface, StreamFactoryInterface, UploadedFileFactoryInterface, UriFactoryInterface
 {
     public function createRequest(string $method, $uri): RequestInterface
     {

--- a/src/Request.php
+++ b/src/Request.php
@@ -9,8 +9,10 @@ use Psr\Http\Message\{RequestInterface, StreamInterface, UriInterface};
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  * @author Martijn van der Ven <martijn@vanderven.se>
+ *
+ * @final There is no situation where it is a good idea to extend this class.
  */
-final class Request implements RequestInterface
+class Request implements RequestInterface
 {
     use MessageTrait;
     use RequestTrait;

--- a/src/Request.php
+++ b/src/Request.php
@@ -10,7 +10,7 @@ use Psr\Http\Message\{RequestInterface, StreamInterface, UriInterface};
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  * @author Martijn van der Ven <martijn@vanderven.se>
  *
- * @final There is no situation where it is a good idea to extend this class.
+ * @final This class should never be extended. See https://github.com/Nyholm/psr7/blob/master/doc/final.md
  */
 class Request implements RequestInterface
 {

--- a/src/Response.php
+++ b/src/Response.php
@@ -10,8 +10,10 @@ use Psr\Http\Message\{ResponseInterface, StreamInterface};
  * @author Michael Dowling and contributors to guzzlehttp/psr7
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  * @author Martijn van der Ven <martijn@vanderven.se>
+ *
+ * @final There is no situation where it is a good idea to extend this class.
  */
-final class Response implements ResponseInterface
+class Response implements ResponseInterface
 {
     use MessageTrait;
 

--- a/src/Response.php
+++ b/src/Response.php
@@ -11,7 +11,7 @@ use Psr\Http\Message\{ResponseInterface, StreamInterface};
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  * @author Martijn van der Ven <martijn@vanderven.se>
  *
- * @final There is no situation where it is a good idea to extend this class.
+ * @final This class should never be extended. See https://github.com/Nyholm/psr7/blob/master/doc/final.md
  */
 class Response implements ResponseInterface
 {

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -11,7 +11,7 @@ use Psr\Http\Message\{ServerRequestInterface, StreamInterface, UploadedFileInter
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  * @author Martijn van der Ven <martijn@vanderven.se>
  *
- * @final There is no situation where it is a good idea to extend this class.
+ * @final This class should never be extended. See https://github.com/Nyholm/psr7/blob/master/doc/final.md
  */
 class ServerRequest implements ServerRequestInterface
 {

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -10,8 +10,10 @@ use Psr\Http\Message\{ServerRequestInterface, StreamInterface, UploadedFileInter
  * @author Michael Dowling and contributors to guzzlehttp/psr7
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  * @author Martijn van der Ven <martijn@vanderven.se>
+ *
+ * @final There is no situation where it is a good idea to extend this class.
  */
-final class ServerRequest implements ServerRequestInterface
+class ServerRequest implements ServerRequestInterface
 {
     use MessageTrait;
     use RequestTrait;

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -12,8 +12,10 @@ use Symfony\Component\ErrorHandler\ErrorHandler as SymfonyErrorHandler;
  * @author Michael Dowling and contributors to guzzlehttp/psr7
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  * @author Martijn van der Ven <martijn@vanderven.se>
+ *
+ * @final There is no situation where it is a good idea to extend this class.
  */
-final class Stream implements StreamInterface
+class Stream implements StreamInterface
 {
     /** @var resource|null A resource reference */
     private $stream;

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -13,7 +13,7 @@ use Symfony\Component\ErrorHandler\ErrorHandler as SymfonyErrorHandler;
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  * @author Martijn van der Ven <martijn@vanderven.se>
  *
- * @final There is no situation where it is a good idea to extend this class.
+ * @final This class should never be extended. See https://github.com/Nyholm/psr7/blob/master/doc/final.md
  */
 class Stream implements StreamInterface
 {

--- a/src/UploadedFile.php
+++ b/src/UploadedFile.php
@@ -10,8 +10,10 @@ use Psr\Http\Message\{StreamInterface, UploadedFileInterface};
  * @author Michael Dowling and contributors to guzzlehttp/psr7
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  * @author Martijn van der Ven <martijn@vanderven.se>
+ *
+ * @final There is no situation where it is a good idea to extend this class.
  */
-final class UploadedFile implements UploadedFileInterface
+class UploadedFile implements UploadedFileInterface
 {
     /** @var array */
     private const ERRORS = [

--- a/src/UploadedFile.php
+++ b/src/UploadedFile.php
@@ -11,7 +11,7 @@ use Psr\Http\Message\{StreamInterface, UploadedFileInterface};
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  * @author Martijn van der Ven <martijn@vanderven.se>
  *
- * @final There is no situation where it is a good idea to extend this class.
+ * @final This class should never be extended. See https://github.com/Nyholm/psr7/blob/master/doc/final.md
  */
 class UploadedFile implements UploadedFileInterface
 {

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -14,8 +14,10 @@ use Psr\Http\Message\UriInterface;
  * @author Matthew Weier O'Phinney
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  * @author Martijn van der Ven <martijn@vanderven.se>
+ *
+ * @final There is no situation where it is a good idea to extend this class.
  */
-final class Uri implements UriInterface
+class Uri implements UriInterface
 {
     use LowercaseTrait;
 

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -15,7 +15,7 @@ use Psr\Http\Message\UriInterface;
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  * @author Martijn van der Ven <martijn@vanderven.se>
  *
- * @final There is no situation where it is a good idea to extend this class.
+ * @final This class should never be extended. See https://github.com/Nyholm/psr7/blob/master/doc/final.md
  */
 class Uri implements UriInterface
 {


### PR DESCRIPTION
I don't think there is any benefit to remove the `final` keyword. All the good software scientists and best practises says that you should never efter extend these value objects. 

However, some people insists on writing code that I don't approve of and from their perspective the `final` keyword is just annoying. 

This PR does not change the concept, but technically it allows some people to write the code they want to write even tough I consider it suboptimal. 

-----

Edit: When I read this description again, it looks that Im condescending. Im really not. Im trying to be pragmatic. 