### PR TITLE
Wrap fopen for PHP 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
-## Unreleased
+## 1.4.1
 
 ### Fixed
 
 - `Stream::create` with a string needs to rewind the created memory stream.
+- `Psr17Factory::createStreamFromFile`, `UploadedFile::moveTo`, and
+  `UploadedFile::getStream` no longer throw `ValueError` in PHP 8.
 
 ## 1.4.0
 
@@ -118,4 +120,3 @@ The `final` keyword was replaced by `@final` annotation.
 ## 0.2.3
 
 No changelog before this release
-

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require-dev": {
         "phpunit/phpunit": "^7.5 || 8.5 || 9.4",
         "php-http/psr7-integration-tests": "^1.0",
-        "http-interop/http-factory-tests": "^0.8",
+        "http-interop/http-factory-tests": "^0.9",
         "symfony/error-handler": "^4.4"
     },
     "provide": {

--- a/src/Factory/Psr17Factory.php
+++ b/src/Factory/Psr17Factory.php
@@ -37,7 +37,21 @@ class Psr17Factory implements RequestFactoryInterface, ResponseFactoryInterface,
 
     public function createStreamFromFile(string $filename, string $mode = 'r'): StreamInterface
     {
-        return Stream::createFromFile($filename, $mode);
+        try {
+            $resource = @\fopen($filename, $mode);
+        } catch (\Throwable $e) {
+            throw new \RuntimeException('The file ' . $filename . ' cannot be opened.');
+        }
+
+        if (false === $resource) {
+            if ('' === $mode || false === \in_array($mode[0], ['r', 'w', 'a', 'x', 'c'], true)) {
+                throw new \InvalidArgumentException('The mode ' . $mode . ' is invalid.');
+            }
+
+            throw new \RuntimeException('The file ' . $filename . ' cannot be opened.');
+        }
+
+        return Stream::create($resource);
     }
 
     public function createStreamFromResource($resource): StreamInterface

--- a/src/Factory/Psr17Factory.php
+++ b/src/Factory/Psr17Factory.php
@@ -37,16 +37,7 @@ class Psr17Factory implements RequestFactoryInterface, ResponseFactoryInterface,
 
     public function createStreamFromFile(string $filename, string $mode = 'r'): StreamInterface
     {
-        $resource = @\fopen($filename, $mode);
-        if (false === $resource) {
-            if ('' === $mode || false === \in_array($mode[0], ['r', 'w', 'a', 'x', 'c'])) {
-                throw new \InvalidArgumentException('The mode ' . $mode . ' is invalid.');
-            }
-
-            throw new \RuntimeException('The file ' . $filename . ' cannot be opened.');
-        }
-
-        return Stream::create($resource);
+        return Stream::createFromFile($filename, $mode);
     }
 
     public function createStreamFromResource($resource): StreamInterface

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -61,6 +61,7 @@ class Stream implements StreamInterface
      * @param string|resource|StreamInterface $body
      *
      * @throws \InvalidArgumentException
+     * @throws \ValueError
      */
     public static function create($body = ''): StreamInterface
     {
@@ -87,6 +88,29 @@ class Stream implements StreamInterface
         }
 
         throw new \InvalidArgumentException('First argument to Stream::create() must be a string, resource or StreamInterface.');
+    }
+
+    /**
+     * Creates a new PSR-7 stream from path.
+     *
+     * @internal Implements Psr\Http\Message\StreamFactoryInterface::createStreamFromFile for internal use, library users should default to the actual Factory object
+     */
+    public static function createFromFile(string $filename, string $mode = 'r'): StreamInterface
+    {
+        try {
+            $resource = @\fopen($filename, $mode);
+        } catch (\Throwable $e) {
+            throw new \RuntimeException('The file ' . $filename . ' cannot be opened.');
+        }
+        if (false === $resource) {
+            if ('' === $mode || false === \in_array($mode[0], ['r', 'w', 'a', 'x', 'c'], true)) {
+                throw new \InvalidArgumentException('The mode ' . $mode . ' is invalid.');
+            }
+
+            throw new \RuntimeException('The file ' . $filename . ' cannot be opened.');
+        }
+
+        return self::create($resource);
     }
 
     /**

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -61,7 +61,6 @@ class Stream implements StreamInterface
      * @param string|resource|StreamInterface $body
      *
      * @throws \InvalidArgumentException
-     * @throws \ValueError
      */
     public static function create($body = ''): StreamInterface
     {
@@ -88,29 +87,6 @@ class Stream implements StreamInterface
         }
 
         throw new \InvalidArgumentException('First argument to Stream::create() must be a string, resource or StreamInterface.');
-    }
-
-    /**
-     * Creates a new PSR-7 stream from path.
-     *
-     * @internal Implements Psr\Http\Message\StreamFactoryInterface::createStreamFromFile for internal use, library users should default to the actual Factory object
-     */
-    public static function createFromFile(string $filename, string $mode = 'r'): StreamInterface
-    {
-        try {
-            $resource = @\fopen($filename, $mode);
-        } catch (\Throwable $e) {
-            throw new \RuntimeException('The file ' . $filename . ' cannot be opened.');
-        }
-        if (false === $resource) {
-            if ('' === $mode || false === \in_array($mode[0], ['r', 'w', 'a', 'x', 'c'], true)) {
-                throw new \InvalidArgumentException('The mode ' . $mode . ' is invalid.');
-            }
-
-            throw new \RuntimeException('The file ' . $filename . ' cannot be opened.');
-        }
-
-        return self::create($resource);
     }
 
     /**

--- a/src/UploadedFile.php
+++ b/src/UploadedFile.php
@@ -114,9 +114,7 @@ class UploadedFile implements UploadedFileInterface
             return $this->stream;
         }
 
-        $resource = \fopen($this->file, 'r');
-
-        return Stream::create($resource);
+        return Stream::createFromFile($this->file, 'r');
     }
 
     public function moveTo($targetPath): void
@@ -136,7 +134,7 @@ class UploadedFile implements UploadedFileInterface
             }
 
             // Copy the contents of a stream into another stream until end-of-file.
-            $dest = Stream::create(\fopen($targetPath, 'w'));
+            $dest = Stream::createFromFile($targetPath, 'w');
             while (!$stream->eof()) {
                 if (!$dest->write($stream->read(1048576))) {
                     break;

--- a/src/UploadedFile.php
+++ b/src/UploadedFile.php
@@ -114,7 +114,11 @@ class UploadedFile implements UploadedFileInterface
             return $this->stream;
         }
 
-        return Stream::createFromFile($this->file, 'r');
+        try {
+            return Stream::create(\fopen($this->file, 'r'));
+        } catch (\Throwable $e) {
+            throw new \RuntimeException('The file ' . $this->file . ' cannot be opened.');
+        }
     }
 
     public function moveTo($targetPath): void
@@ -133,8 +137,13 @@ class UploadedFile implements UploadedFileInterface
                 $stream->rewind();
             }
 
-            // Copy the contents of a stream into another stream until end-of-file.
-            $dest = Stream::createFromFile($targetPath, 'w');
+            try {
+                // Copy the contents of a stream into another stream until end-of-file.
+                $dest = Stream::create(\fopen($targetPath, 'w'));
+            } catch (\Throwable $e) {
+                throw new \RuntimeException('The file ' . $targetPath . ' cannot be opened.');
+            }
+
             while (!$stream->eof()) {
                 if (!$dest->write($stream->read(1048576))) {
                     break;


### PR DESCRIPTION
`fopen()` has new behaviour where it will throw an error in PHP 8. Some projects have bumped into this, e.g. [Drupal](https://www.drupal.org/project/drupal/issues/3177541) and [the HTTP Factory tests](https://github.com/http-interop/http-factory-tests/pull/46).

This PR wraps our uses of `fopen()` to not leak the `ValueError` to library users.

Marking as WIP as I haven’t looked at tests yet. But have a look and see if these changes seem right!