### PR TITLE
Revert #177

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- `Stream::create` with a string needs to rewind the created memory stream.
 - `Psr17Factory::createStreamFromFile`, `UploadedFile::moveTo`, and
   `UploadedFile::getStream` no longer throw `ValueError` in PHP 8.
 

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -71,7 +71,6 @@ class Stream implements StreamInterface
         if (\is_string($body)) {
             $resource = \fopen('php://temp', 'rw+');
             \fwrite($resource, $body);
-            \rewind($resource);
             $body = $resource;
         }
 

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -47,7 +47,8 @@ class StreamTest extends TestCase
     public function testBuildFromString()
     {
         $stream = Stream::create('data');
-        $this->assertEquals('data', $stream->getContents());
+        $this->assertEquals('', $stream->getContents());
+        $this->assertEquals('data', $stream->__toString());
         $stream->close();
     }
 


### PR DESCRIPTION
This will revert #177 so we don't introduce new behaviour. This will fix #180. 

FYI @Zegnat @dbu. The discussion in #180 stalled a bit. By reverting this we are predictable (but maybe wrong), we are also consistent between creating a stream from string compared to from resource. 