### PR TITLE
Improve error handling

### DIFF
--- a/src/Factory/Psr17Factory.php
+++ b/src/Factory/Psr17Factory.php
@@ -37,18 +37,16 @@ class Psr17Factory implements RequestFactoryInterface, ResponseFactoryInterface,
 
     public function createStreamFromFile(string $filename, string $mode = 'r'): StreamInterface
     {
-        try {
-            $resource = @\fopen($filename, $mode);
-        } catch (\Throwable $e) {
-            throw new \RuntimeException(\sprintf('The file "%s" cannot be opened.', $filename));
+        if ('' === $filename) {
+            throw new \RuntimeException('Path cannot be empty');
         }
 
-        if (false === $resource) {
+        if (false === $resource = @\fopen($filename, $mode)) {
             if ('' === $mode || false === \in_array($mode[0], ['r', 'w', 'a', 'x', 'c'], true)) {
                 throw new \InvalidArgumentException(\sprintf('The mode "%s" is invalid.', $mode));
             }
 
-            throw new \RuntimeException(\sprintf('The file "%s" cannot be opened.', $filename));
+            throw new \RuntimeException(\sprintf('The file "%s" cannot be opened: %s', $filename, \error_get_last()['message'] ?? ''));
         }
 
         return Stream::create($resource);

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -185,8 +185,12 @@ class Stream implements StreamInterface
 
     public function tell(): int
     {
-        if (false === $result = \ftell($this->stream)) {
-            throw new \RuntimeException('Unable to determine stream position');
+        if (!isset($this->stream)) {
+            throw new \RuntimeException('Stream is detached');
+        }
+
+        if (false === $result = @\ftell($this->stream)) {
+            throw new \RuntimeException('Unable to determine stream position: ' . (\error_get_last()['message'] ?? ''));
         }
 
         return $result;
@@ -194,7 +198,7 @@ class Stream implements StreamInterface
 
     public function eof(): bool
     {
-        return !$this->stream || \feof($this->stream);
+        return !isset($this->stream) || \feof($this->stream);
     }
 
     public function isSeekable(): bool
@@ -204,6 +208,10 @@ class Stream implements StreamInterface
 
     public function seek($offset, $whence = \SEEK_SET): void
     {
+        if (!isset($this->stream)) {
+            throw new \RuntimeException('Stream is detached');
+        }
+
         if (!$this->seekable) {
             throw new \RuntimeException('Stream is not seekable');
         }
@@ -225,6 +233,10 @@ class Stream implements StreamInterface
 
     public function write($string): int
     {
+        if (!isset($this->stream)) {
+            throw new \RuntimeException('Stream is detached');
+        }
+
         if (!$this->writable) {
             throw new \RuntimeException('Cannot write to a non-writable stream');
         }
@@ -232,8 +244,8 @@ class Stream implements StreamInterface
         // We can't know the size after writing anything
         $this->size = null;
 
-        if (false === $result = \fwrite($this->stream, $string)) {
-            throw new \RuntimeException('Unable to write to stream');
+        if (false === $result = @\fwrite($this->stream, $string)) {
+            throw new \RuntimeException('Unable to write to stream: ' . (\error_get_last()['message'] ?? ''));
         }
 
         return $result;
@@ -246,12 +258,16 @@ class Stream implements StreamInterface
 
     public function read($length): string
     {
+        if (!isset($this->stream)) {
+            throw new \RuntimeException('Stream is detached');
+        }
+
         if (!$this->readable) {
             throw new \RuntimeException('Cannot read from non-readable stream');
         }
 
-        if (false === $result = \fread($this->stream, $length)) {
-            throw new \RuntimeException('Unable to read from stream');
+        if (false === $result = @\fread($this->stream, $length)) {
+            throw new \RuntimeException('Unable to read from stream: ' . (\error_get_last()['message'] ?? ''));
         }
 
         return $result;
@@ -260,11 +276,11 @@ class Stream implements StreamInterface
     public function getContents(): string
     {
         if (!isset($this->stream)) {
-            throw new \RuntimeException('Unable to read stream contents');
+            throw new \RuntimeException('Stream is detached');
         }
 
-        if (false === $contents = \stream_get_contents($this->stream)) {
-            throw new \RuntimeException('Unable to read stream contents');
+        if (false === $contents = @\stream_get_contents($this->stream)) {
+            throw new \RuntimeException('Unable to read stream contents: ' . (\error_get_last()['message'] ?? ''));
         }
 
         return $contents;


### PR DESCRIPTION
The current logic breaks when eg `stream_get_contents()` triggers a warning after a timeout.
See https://github.com/symfony/symfony/issues/42100 for background.
guzzle/psr7 has the same issue btw.