### PR TITLE
Add explicit `@return mixed` phpdoc

### DIFF
--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -133,6 +133,9 @@ class ServerRequest implements ServerRequestInterface
         return $this->attributes;
     }
 
+    /**
+     * @return mixed
+     */
     public function getAttribute($attribute, $default = null)
     {
         if (false === \array_key_exists($attribute, $this->attributes)) {

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -286,6 +286,9 @@ class Stream implements StreamInterface
         return $contents;
     }
 
+    /**
+     * @return mixed
+     */
     public function getMetadata($key = null)
     {
         if (!isset($this->stream)) {


### PR DESCRIPTION
This will allow removing one deprecation notice from the Symfony codebase:

> Method "Psr\Http\Message\StreamInterface::getMetadata()" will return "mixed" as of its next major version. Doing the same in implementation "Nyholm\Psr7\Stream" will be required when upgrading.