### PR TITLE
Add return types to HttplugFactory

### DIFF
--- a/src/Factory/HttplugFactory.php
+++ b/src/Factory/HttplugFactory.php
@@ -6,6 +6,9 @@ namespace Nyholm\Psr7\Factory;
 
 use Http\Message\{MessageFactory, StreamFactory, UriFactory};
 use Nyholm\Psr7\{Request, Response, Stream, Uri};
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
 
 /**
@@ -16,17 +19,17 @@ use Psr\Http\Message\UriInterface;
  */
 class HttplugFactory implements MessageFactory, StreamFactory, UriFactory
 {
-    public function createRequest($method, $uri, array $headers = [], $body = null, $protocolVersion = '1.1')
+    public function createRequest($method, $uri, array $headers = [], $body = null, $protocolVersion = '1.1'): RequestInterface
     {
         return new Request($method, $uri, $headers, $body, $protocolVersion);
     }
 
-    public function createResponse($statusCode = 200, $reasonPhrase = null, array $headers = [], $body = null, $version = '1.1')
+    public function createResponse($statusCode = 200, $reasonPhrase = null, array $headers = [], $body = null, $version = '1.1'): ResponseInterface
     {
         return new Response((int) $statusCode, $headers, $body, $version, $reasonPhrase);
     }
 
-    public function createStream($body = null)
+    public function createStream($body = null): StreamInterface
     {
         return Stream::create($body ?? '');
     }


### PR DESCRIPTION
This is needed to do now because symfony/error-handler triggers deprecation notices such these

```
  1x: Method "Http\Message\RequestFactory::createRequest()" might add "RequestInterface" as a native return type declaration in the future. Do the same in implementation "Nyholm\Psr7\Factory\HttplugFactory" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in DiscoveredClientsTest::testForcedDiscovery from Http\HttplugBundle\Tests\Functional

  1x: Method "Http\Message\ResponseFactory::createResponse()" might add "ResponseInterface" as a native return type declaration in the future. Do the same in implementation "Nyholm\Psr7\Factory\HttplugFactory" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in DiscoveredClientsTest::testForcedDiscovery from Http\HttplugBundle\Tests\Functional

  1x: Method "Http\Message\StreamFactory::createStream()" might add "StreamInterface" as a native return type declaration in the future. Do the same in implementation "Nyholm\Psr7\Factory\HttplugFactory" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in DiscoveredClientsTest::testForcedDiscovery from Http\HttplugBundle\Tests\Functional
```