### PR TITLE
Fixed deprecation messages for PHP 8.1

### DIFF
--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -77,7 +77,7 @@ class ServerRequest implements ServerRequestInterface
         return $this->uploadedFiles;
     }
 
-    public function withUploadedFiles(array $uploadedFiles)
+    public function withUploadedFiles(array $uploadedFiles): self
     {
         $new = clone $this;
         $new->uploadedFiles = $uploadedFiles;
@@ -90,7 +90,7 @@ class ServerRequest implements ServerRequestInterface
         return $this->cookieParams;
     }
 
-    public function withCookieParams(array $cookies)
+    public function withCookieParams(array $cookies): self
     {
         $new = clone $this;
         $new->cookieParams = $cookies;
@@ -103,7 +103,7 @@ class ServerRequest implements ServerRequestInterface
         return $this->queryParams;
     }
 
-    public function withQueryParams(array $query)
+    public function withQueryParams(array $query): self
     {
         $new = clone $this;
         $new->queryParams = $query;
@@ -111,12 +111,15 @@ class ServerRequest implements ServerRequestInterface
         return $new;
     }
 
+    /**
+     * @return array|object|null
+     */
     public function getParsedBody()
     {
         return $this->parsedBody;
     }
 
-    public function withParsedBody($data)
+    public function withParsedBody($data): self
     {
         if (!\is_array($data) && !\is_object($data) && null !== $data) {
             throw new \InvalidArgumentException('First parameter to withParsedBody MUST be object, array or null');


### PR DESCRIPTION
Just added return types to ServerRequest class where they were not specified. The goal is to fixes deprecation messages on PHP8.1 as the ones below:

```
 1x: Method "Psr\Http\Message\ServerRequestInterface::withUploadedFiles()" might add "static" as a native return type declaration in the future. Do the same in implementation "Nyholm\Psr7\ServerRequest" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in OAuth2GenerateTokenActionTest::testItCallsSuccessfullyOauth2GenerateTokenEndpointTest from App\Tests\Functional\Action

  1x: Method "Psr\Http\Message\ServerRequestInterface::withCookieParams()" might add "static" as a native return type declaration in the future. Do the same in implementation "Nyholm\Psr7\ServerRequest" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in OAuth2GenerateTokenActionTest::testItCallsSuccessfullyOauth2GenerateTokenEndpointTest from App\Tests\Functional\Action

  1x: Method "Psr\Http\Message\ServerRequestInterface::withQueryParams()" might add "static" as a native return type declaration in the future. Do the same in implementation "Nyholm\Psr7\ServerRequest" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in OAuth2GenerateTokenActionTest::testItCallsSuccessfullyOauth2GenerateTokenEndpointTest from App\Tests\Functional\Action

  1x: Method "Psr\Http\Message\ServerRequestInterface::getParsedBody()" might add "array|object|null" as a native return type declaration in the future. Do the same in implementation "Nyholm\Psr7\ServerRequest" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in OAuth2GenerateTokenActionTest::testItCallsSuccessfullyOauth2GenerateTokenEndpointTest from App\Tests\Functional\Action

  1x: Method "Psr\Http\Message\ServerRequestInterface::withParsedBody()" might add "static" as a native return type declaration in the future. Do the same in implementation "Nyholm\Psr7\ServerRequest" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in OAuth2GenerateTokenActionTest::testItCallsSuccessfullyOauth2GenerateTokenEndpointTest from App\Tests\Functional\Action
```

Please let me know if adjustments are needed

This will fix #195