### PR TITLE
Resolve symfony/error-handler deprecations

### DIFF
--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -77,7 +77,7 @@ class ServerRequest implements ServerRequestInterface
         return $this->uploadedFiles;
     }
 
-    public function withUploadedFiles(array $uploadedFiles)
+    public function withUploadedFiles(array $uploadedFiles): self
     {
         $new = clone $this;
         $new->uploadedFiles = $uploadedFiles;
@@ -90,7 +90,7 @@ class ServerRequest implements ServerRequestInterface
         return $this->cookieParams;
     }
 
-    public function withCookieParams(array $cookies)
+    public function withCookieParams(array $cookies): self
     {
         $new = clone $this;
         $new->cookieParams = $cookies;
@@ -103,7 +103,7 @@ class ServerRequest implements ServerRequestInterface
         return $this->queryParams;
     }
 
-    public function withQueryParams(array $query)
+    public function withQueryParams(array $query): self
     {
         $new = clone $this;
         $new->queryParams = $query;
@@ -111,12 +111,15 @@ class ServerRequest implements ServerRequestInterface
         return $new;
     }
 
+    /**
+     * @return array|object|null
+     */
     public function getParsedBody()
     {
         return $this->parsedBody;
     }
 
-    public function withParsedBody($data)
+    public function withParsedBody($data): self
     {
         if (!\is_array($data) && !\is_object($data) && null !== $data) {
             throw new \InvalidArgumentException('First parameter to withParsedBody MUST be object, array or null');

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -77,7 +77,10 @@ class ServerRequest implements ServerRequestInterface
         return $this->uploadedFiles;
     }
 
-    public function withUploadedFiles(array $uploadedFiles): self
+    /**
+     * @return static
+     */
+    public function withUploadedFiles(array $uploadedFiles)
     {
         $new = clone $this;
         $new->uploadedFiles = $uploadedFiles;
@@ -90,7 +93,10 @@ class ServerRequest implements ServerRequestInterface
         return $this->cookieParams;
     }
 
-    public function withCookieParams(array $cookies): self
+    /**
+     * @return static
+     */
+    public function withCookieParams(array $cookies)
     {
         $new = clone $this;
         $new->cookieParams = $cookies;
@@ -103,7 +109,10 @@ class ServerRequest implements ServerRequestInterface
         return $this->queryParams;
     }
 
-    public function withQueryParams(array $query): self
+    /**
+     * @return static
+     */
+    public function withQueryParams(array $query)
     {
         $new = clone $this;
         $new->queryParams = $query;
@@ -119,7 +128,10 @@ class ServerRequest implements ServerRequestInterface
         return $this->parsedBody;
     }
 
-    public function withParsedBody($data): self
+    /**
+     * @return static
+     */
+    public function withParsedBody($data)
     {
         if (!\is_array($data) && !\is_object($data) && null !== $data) {
             throw new \InvalidArgumentException('First parameter to withParsedBody MUST be object, array or null');

--- a/tests/Integration/RequestTest.php
+++ b/tests/Integration/RequestTest.php
@@ -2,12 +2,13 @@
 
 namespace Tests\Nyholm\Psr7\Integration;
 
+use Psr\Http\Message\RequestInterface;
 use Http\Psr7Test\RequestIntegrationTest;
 use Nyholm\Psr7\Request;
 
 class RequestTest extends RequestIntegrationTest
 {
-    public function createSubject()
+    public function createSubject(): RequestInterface
     {
         return new Request('GET', '/');
     }

--- a/tests/Integration/ResponseTest.php
+++ b/tests/Integration/ResponseTest.php
@@ -2,12 +2,13 @@
 
 namespace Tests\Nyholm\Psr7\Integration;
 
+use Psr\Http\Message\ResponseInterface;
 use Http\Psr7Test\ResponseIntegrationTest;
 use Nyholm\Psr7\Response;
 
 class ResponseTest extends ResponseIntegrationTest
 {
-    public function createSubject()
+    public function createSubject(): ResponseInterface
     {
         return new Response();
     }

--- a/tests/Integration/ServerRequestTest.php
+++ b/tests/Integration/ServerRequestTest.php
@@ -2,12 +2,13 @@
 
 namespace Tests\Nyholm\Psr7\Integration;
 
+use Psr\Http\Message\ServerRequestInterface;
 use Http\Psr7Test\ServerRequestIntegrationTest;
 use Nyholm\Psr7\ServerRequest;
 
 class ServerRequestTest extends ServerRequestIntegrationTest
 {
-    public function createSubject()
+    public function createSubject(): ServerRequestInterface
     {
         $_SERVER['REQUEST_METHOD'] = 'GET';
 

--- a/tests/Integration/StreamTest.php
+++ b/tests/Integration/StreamTest.php
@@ -2,12 +2,13 @@
 
 namespace Tests\Nyholm\Psr7\Integration;
 
+use Psr\Http\Message\StreamInterface;
 use Http\Psr7Test\StreamIntegrationTest;
 use Nyholm\Psr7\Stream;
 
 class StreamTest extends StreamIntegrationTest
 {
-    public function createStream($data)
+    public function createStream($data): StreamInterface
     {
         return Stream::create($data);
     }

--- a/tests/Integration/UploadedFileTest.php
+++ b/tests/Integration/UploadedFileTest.php
@@ -2,13 +2,14 @@
 
 namespace Tests\Nyholm\Psr7\Integration;
 
+use Psr\Http\Message\UploadedFileInterface;
 use Http\Psr7Test\UploadedFileIntegrationTest;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Nyholm\Psr7\Stream;
 
 class UploadedFileTest extends UploadedFileIntegrationTest
 {
-    public function createSubject()
+    public function createSubject(): UploadedFileInterface
     {
         return (new Psr17Factory())->createUploadedFile(Stream::create('writing to tempfile'));
     }

--- a/tests/Integration/UriTest.php
+++ b/tests/Integration/UriTest.php
@@ -2,12 +2,13 @@
 
 namespace Tests\Nyholm\Psr7\Integration;
 
+use Psr\Http\Message\UriInterface;
 use Http\Psr7Test\UriIntegrationTest;
 use Nyholm\Psr7\Uri;
 
 class UriTest extends UriIntegrationTest
 {
-    public function createUri($uri)
+    public function createUri($uri): UriInterface
     {
         return new Uri($uri);
     }


### PR DESCRIPTION
Alternative to https://github.com/Nyholm/psr7/pull/196

My suggestion about using `#[\ReturnTypeWillChange]` was wrong. This attribute is required only in the case of implementing SPL interfaces (like a `\ArrayAccess`, etc)

So these deprecations are triggered only from `symfony/error-handler` (with enabled debug).
Also applied changes to tests (applied automatically with running `patch-type-declarations` https://symfony.com/doc/5.4/setup/upgrade_major.html#upgrading-to-symfony-6-add-native-return-types)