### PR TITLE
Fixed rawurlencode for userInfo in Uri

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -145,12 +145,12 @@ class Uri implements UriInterface
     public function withUserInfo($user, $password = null): self
     {
         if ($user !== \rawurlencode($user)) {
-            throw new \InvalidArgumentException("The user contains invalid URL characters. Please use rawurlencode()");
+            throw new \InvalidArgumentException('The user contains invalid URL characters. Please use rawurlencode()');
         }
         $info = $user;
         if (null !== $password && '' !== $password) {
             if ($password !== \rawurlencode($password)) {
-                throw new \InvalidArgumentException("The password contains invalid URL characters. Please use rawurlencode()");
+                throw new \InvalidArgumentException('The password contains invalid URL characters. Please use rawurlencode()');
             }
             $info .= ':' . $password;
         }

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -25,6 +25,10 @@ class Uri implements UriInterface
 
     private const CHAR_SUB_DELIMS = '!\$&\'\(\)\*\+,;=';
 
+    private const CHAR_HEXDIGIT = 'A-Fa-f0-9';
+
+    private const REGEX_USERINFO = '^(?:[' . self::CHAR_UNRESERVED . self::CHAR_SUB_DELIMS . ':]|%[' . self::CHAR_HEXDIGIT . ']{2})+$';
+
     /** @var string Uri scheme. */
     private $scheme = '';
 
@@ -144,17 +148,14 @@ class Uri implements UriInterface
 
     public function withUserInfo($user, $password = null): self
     {
-        if ($user !== \rawurlencode($user)) {
-            throw new \InvalidArgumentException('The user contains invalid URL characters. Please use rawurlencode()');
-        }
         $info = $user;
         if (null !== $password && '' !== $password) {
-            if ($password !== \rawurlencode($password)) {
-                throw new \InvalidArgumentException('The password contains invalid URL characters. Please use rawurlencode()');
-            }
             $info .= ':' . $password;
         }
 
+        if (!\preg_match('/' . self::REGEX_USERINFO . '/', $info)) {
+            throw new \InvalidArgumentException('The user info contains invalid URL characters. Please use rawurlencode()');
+        }
         if ($this->userInfo === $info) {
             return $this;
         }

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -144,9 +144,9 @@ class Uri implements UriInterface
 
     public function withUserInfo($user, $password = null): self
     {
-        $info = rawurlencode($user);
+        $info = \rawurlencode($user);
         if (null !== $password && '' !== $password) {
-            $info .= ':' . rawurlencode($password);
+            $info .= ':' . \rawurlencode($password);
         }
 
         if ($this->userInfo === $info) {

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -144,15 +144,15 @@ class Uri implements UriInterface
 
     public function withUserInfo($user, $password = null): self
     {
-        if ($user !== rawurlencode($user)) {
+        if ($user !== \rawurlencode($user)) {
             throw new \InvalidArgumentException("The user contains invalid URL characters. Please use rawurlencode()");
         }
         $info = $user;
         if (null !== $password && '' !== $password) {
-            if ($password !== rawurlencode($password)) {
+            if ($password !== \rawurlencode($password)) {
                 throw new \InvalidArgumentException("The password contains invalid URL characters. Please use rawurlencode()");
             }
-            $info .= ':' . \rawurlencode($password);
+            $info .= ':' . $password;
         }
 
         if ($this->userInfo === $info) {

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -144,9 +144,9 @@ class Uri implements UriInterface
 
     public function withUserInfo($user, $password = null): self
     {
-        $info = $user;
+        $info = rawurlencode($user);
         if (null !== $password && '' !== $password) {
-            $info .= ':' . $password;
+            $info .= ':' . rawurlencode($password);
         }
 
         if ($this->userInfo === $info) {

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -144,8 +144,14 @@ class Uri implements UriInterface
 
     public function withUserInfo($user, $password = null): self
     {
-        $info = \rawurlencode($user);
+        if ($user !== rawurlencode($user)) {
+            throw new \InvalidArgumentException("The user contains invalid URL characters. Please use rawurlencode()");
+        }
+        $info = $user;
         if (null !== $password && '' !== $password) {
+            if ($password !== rawurlencode($password)) {
+                throw new \InvalidArgumentException("The password contains invalid URL characters. Please use rawurlencode()");
+            }
             $info .= ':' . \rawurlencode($password);
         }
 

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -495,14 +495,24 @@ class UriTest extends TestCase
         $this->assertSame('//' . $testDomain, (string) $uri);
     }
 
-    public function testWithUserInfoWithSpecialCharacters()
+    public function testWithUserInfoWithInvalidUserCharacters()
     {
         $uri = new Uri();
         $user = 'foo@';
         $password = 'password';
 
+        $this->expectException(\InvalidArgumentException::class);
         $uri = $uri->withUserInfo($user, $password);
-        $this->assertEquals(rawurlencode($user) . ':' . rawurlencode($password), $uri->getUserInfo());
+    }
+
+    public function testWithUserInfoWithInvalidPasswordCharacters()
+    {
+        $uri = new Uri();
+        $user = 'foo';
+        $password = 'password@';
+
+        $this->expectException(\InvalidArgumentException::class);
+        $uri = $uri->withUserInfo($user, $password);
     }
 
     public function testContructorWithSpecialCharactersInUserInfo()

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -495,13 +495,22 @@ class UriTest extends TestCase
         $this->assertSame('//' . $testDomain, (string) $uri);
     }
 
-    public function testUserInfoWithUrlEncode()
+    public function testWithUserInfoWithSpecialCharacters()
     {
         $uri = new Uri();
         $user = 'foo@';
         $password = 'password';
 
         $uri = $uri->withUserInfo($user, $password);
+        $this->assertEquals(rawurlencode($user) . ':' . rawurlencode($password), $uri->getUserInfo());
+    }
+
+    public function testContructorWithSpecialCharactersInUserInfo()
+    {
+        $user = 'foo@';
+        $password = 'bar';
+        // when passing directly userInfo in URL this must be already encoded
+        $uri = new Uri(sprintf("http://%s:%s@domain.com", rawurlencode($user), rawurlencode($password)));
         $this->assertEquals(rawurlencode($user) . ':' . rawurlencode($password), $uri->getUserInfo());
     }
 }

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -494,4 +494,14 @@ class UriTest extends TestCase
         $this->assertSame($testDomain, $uri->getHost());
         $this->assertSame('//' . $testDomain, (string) $uri);
     }
+
+    public function testUserInfoWithUrlEncode()
+    {
+        $uri = new Uri();
+        $user = 'foo@';
+        $password = 'password';
+
+        $uri = $uri->withUserInfo($user, $password);
+        $this->assertEquals(rawurlencode($user) . ':' . rawurlencode($password), $uri->getUserInfo());
+    }
 }


### PR DESCRIPTION
When you specify a username and password using `Uri::withUserInfo()` these are not encoded for URL (see [here](https://github.com/elastic/elastic-transport-php/pull/7#issuecomment-1171086850)). For instance, if the username is `foo@` and the password is `bar` the userInfo results in `foo@:bar` that is not a valid URL encoded string.

Other PSR-7 implementations use `rawurlencode()` for encoding the characters in the URL (e.g. [Guzzle](https://github.com/guzzle/psr7/issues/252), [Laminas-diactoros](https://github.com/laminas/laminas-diactoros/blob/283204ee45bec928f86229deaf8ca54ec0bc8d33/src/Uri.php#L538-L549)).