### PR TITLE
fix psr17factory create stream

### DIFF
--- a/src/Stream.php
+++ b/src/Stream.php
@@ -71,6 +71,7 @@ class Stream implements StreamInterface
         if (\is_string($body)) {
             $resource = \fopen('php://temp', 'rw+');
             \fwrite($resource, $body);
+            \fseek($resource, 0);
             $body = $resource;
         }
 

--- a/tests/Factory/Psr17FactoryTest.php
+++ b/tests/Factory/Psr17FactoryTest.php
@@ -35,4 +35,24 @@ class Psr17FactoryTest extends TestCase
         $this->assertEquals(567, $r->getStatusCode());
         $this->assertEquals('Foo', $r->getReasonPhrase());
     }
+
+    public function testCreateRequest()
+    {
+        $factory = new Psr17Factory();
+        $req = $factory->createRequest('POST', 'https://nyholm.tech');
+        $body = $factory->createStream('Foo');
+        $req = $req->withBody($body);
+        $this->assertEquals('Foo', $req->getBody()->getContents());
+        $this->assertEquals('', $req->getBody()->getContents());
+        $this->assertEquals('POST', $req->getMethod());
+        $this->assertEquals('https://nyholm.tech', $req->getUri());
+
+        $req = $factory->createRequest('POST', 'https://nyholm.tech');
+        $body = $factory->createStream('');
+        $req = $req->withBody($body);
+        $this->assertEquals('', $req->getBody()->getContents());
+        $this->assertEquals('', $req->getBody()->getContents());
+        $this->assertEquals('POST', $req->getMethod());
+        $this->assertEquals('https://nyholm.tech', $req->getUri());
+    }
 }

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -47,6 +47,7 @@ class StreamTest extends TestCase
     public function testBuildFromString()
     {
         $stream = Stream::create('data');
+        $this->assertEquals('data', $stream->getContents());
         $this->assertEquals('', $stream->getContents());
         $this->assertEquals('data', $stream->__toString());
         $stream->close();


### PR DESCRIPTION
Closes #204 
As a fix, when we have created the stream, we can set the seek again to start of the file so that when we invoke  `$req->getBody()->getContents();` we get the actual body and not empty string.