### PR TITLE
Encode userinfo (but don't double-encode)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "symfony/error-handler": "^4.4"
     },
     "provide": {
+        "php-http/message-factory-implementation": "1.0",
         "psr/http-message-implementation": "1.0",
         "psr/http-factory-implementation": "1.0"
     },

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -144,9 +144,9 @@ class Uri implements UriInterface
 
     public function withUserInfo($user, $password = null): self
     {
-        $info = $user;
+        $info = \rawurlencode(\rawurldecode($user));
         if (null !== $password && '' !== $password) {
-            $info .= ':' . $password;
+            $info .= ':' . \rawurlencode(\rawurldecode($password));
         }
 
         if ($this->userInfo === $info) {

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -31,7 +31,7 @@ class UriTest extends TestCase
     {
         $uri = (new Uri())
             ->withScheme('https')
-            ->withUserInfo('user', 'pass')
+            ->withUserInfo('user%3D=', 'pass%3D=')
             ->withHost('example.com')
             ->withPort(8080)
             ->withPath('/path/123')
@@ -39,14 +39,14 @@ class UriTest extends TestCase
             ->withFragment('test');
 
         $this->assertSame('https', $uri->getScheme());
-        $this->assertSame('user:pass@example.com:8080', $uri->getAuthority());
-        $this->assertSame('user:pass', $uri->getUserInfo());
+        $this->assertSame('user%3D%3D:pass%3D%3D@example.com:8080', $uri->getAuthority());
+        $this->assertSame('user%3D%3D:pass%3D%3D', $uri->getUserInfo());
         $this->assertSame('example.com', $uri->getHost());
         $this->assertSame(8080, $uri->getPort());
         $this->assertSame('/path/123', $uri->getPath());
         $this->assertSame('q=abc', $uri->getQuery());
         $this->assertSame('test', $uri->getFragment());
-        $this->assertSame('https://user:pass@example.com:8080/path/123?q=abc#test', (string) $uri);
+        $this->assertSame('https://user%3D%3D:pass%3D%3D@example.com:8080/path/123?q=abc#test', (string) $uri);
     }
 
     /**


### PR DESCRIPTION
Fix #206

Yes, this is unspecified by the PSR, but the current behavior produces broken URLs, and other mainstream implementations do the same: encoding characters that must be, while preventing double-encoding. I think this makes sense. It's more useful than an exception.