### PR TITLE
Populate ServerRequest::getQueryParams() with query string passed to constructor

### DIFF
--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -54,6 +54,7 @@ class ServerRequest implements ServerRequestInterface
         $this->uri = $uri;
         $this->setHeaders($headers);
         $this->protocol = $version;
+        \parse_str($uri->getQuery(), $this->queryParams);
 
         if (!$this->hasHeader('Host')) {
             $this->updateHostFromUri();

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -49,14 +49,14 @@ class ServerRequestTest extends TestCase
 
     public function testQueryParams()
     {
-        $request1 = new ServerRequest('GET', '/');
+        $request1 = new ServerRequest('GET', '/?foo=bar');
 
         $params = ['name' => 'value'];
 
         $request2 = $request1->withQueryParams($params);
 
         $this->assertNotSame($request2, $request1);
-        $this->assertEmpty($request1->getQueryParams());
+        $this->assertSame(['foo' => 'bar'], $request1->getQueryParams());
         $this->assertSame($params, $request2->getQueryParams());
     }
 


### PR DESCRIPTION
Fix #181