### PR TITLE
Stream: seek to the begining of the string on initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ phpunit.xml
 vendor
 .php_cs.cache
 .phpunit.result.cache
+.tmp

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -81,6 +81,7 @@ class Stream implements StreamInterface
         if (\is_string($body)) {
             $resource = \fopen('php://temp', 'rw+');
             \fwrite($resource, $body);
+            \fseek($resource, 0);
             $body = $resource;
         }
 

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -23,6 +23,14 @@ class ResponseTest extends TestCase
         $this->assertSame('', (string) $r->getBody());
     }
 
+    public function testDefaultConstructorSeekBody()
+    {
+        $r = new Response(200, [], 'Hello');
+        $this->assertSame(200, $r->getStatusCode());
+        $this->assertInstanceOf(StreamInterface::class, $r->getBody());
+        $this->assertSame('Hello', $r->getBody()->getContents());
+    }
+
     public function testCanConstructWithStatusCode()
     {
         $r = new Response(404);

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -26,6 +26,20 @@ class StreamTest extends TestCase
         $stream->close();
     }
 
+    public function testConstructorSeekWithStringContent()
+    {
+        $stream = Stream::create('Hello');
+        $this->assertTrue($stream->isReadable());
+        $this->assertTrue($stream->isWritable());
+        $this->assertTrue($stream->isSeekable());
+        $this->assertEquals('php://temp', $stream->getMetadata('uri'));
+        $this->assertTrue(\is_array($stream->getMetadata()));
+        $this->assertSame(5, $stream->getSize());
+        $this->assertFalse($stream->eof());
+        $this->assertSame('Hello', $stream->getContents());
+        $stream->close();
+    }
+
     public function testStreamClosesHandleOnDestruct()
     {
         $handle = fopen('php://temp', 'r');
@@ -47,7 +61,7 @@ class StreamTest extends TestCase
     public function testBuildFromString()
     {
         $stream = Stream::create('data');
-        $this->assertEquals('', $stream->getContents());
+        $this->assertEquals('data', $stream->getContents());
         $this->assertEquals('data', $stream->__toString());
         $stream->close();
     }


### PR DESCRIPTION
This is useful in test env where we usually 'mock' the response

This is resurrecting #98 by @lyrixx

After years of practice, this is still one of the major pain points when using PSR-7.
Let's make the life or users less surprising.

Fix #99