### PR TITLE
Encode only reserved characters in user-info

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -23,6 +23,8 @@ class Uri implements UriInterface
 
     private const CHAR_SUB_DELIMS = '!\$&\'\(\)\*\+,;=';
 
+    private const CHAR_GEN_DELIMS = ':\/\?#\[\]@';
+
     /** @var string Uri scheme. */
     private $scheme = '';
 
@@ -159,13 +161,13 @@ class Uri implements UriInterface
             throw new \InvalidArgumentException('User must be a string');
         }
 
-        $info = \rawurlencode(\rawurldecode($user));
+        $info = \preg_replace_callback('/[' . self::CHAR_GEN_DELIMS . self::CHAR_SUB_DELIMS . ']++/', [__CLASS__, 'rawurlencodeMatchZero'], $user);
         if (null !== $password && '' !== $password) {
             if (!\is_string($password)) {
                 throw new \InvalidArgumentException('Password must be a string');
             }
 
-            $info .= ':' . \rawurlencode(\rawurldecode($password));
+            $info .= ':' . \preg_replace_callback('/[' . self::CHAR_GEN_DELIMS . self::CHAR_SUB_DELIMS . ']++/', [__CLASS__, 'rawurlencodeMatchZero'], $password);
         }
 
         if ($this->userInfo === $info) {

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -31,7 +31,7 @@ class UriTest extends TestCase
     {
         $uri = (new Uri())
             ->withScheme('https')
-            ->withUserInfo('user%3D=', 'pass%3D=')
+            ->withUserInfo('foo\user%3D=', 'pass%3D=')
             ->withHost('example.com')
             ->withPort(8080)
             ->withPath('/path/123')
@@ -39,14 +39,14 @@ class UriTest extends TestCase
             ->withFragment('test');
 
         $this->assertSame('https', $uri->getScheme());
-        $this->assertSame('user%3D%3D:pass%3D%3D@example.com:8080', $uri->getAuthority());
-        $this->assertSame('user%3D%3D:pass%3D%3D', $uri->getUserInfo());
+        $this->assertSame('foo\user%3D%3D:pass%3D%3D@example.com:8080', $uri->getAuthority());
+        $this->assertSame('foo\user%3D%3D:pass%3D%3D', $uri->getUserInfo());
         $this->assertSame('example.com', $uri->getHost());
         $this->assertSame(8080, $uri->getPort());
         $this->assertSame('/path/123', $uri->getPath());
         $this->assertSame('q=abc', $uri->getQuery());
         $this->assertSame('test', $uri->getFragment());
-        $this->assertSame('https://user%3D%3D:pass%3D%3D@example.com:8080/path/123?q=abc#test', (string) $uri);
+        $this->assertSame('https://foo\user%3D%3D:pass%3D%3D@example.com:8080/path/123?q=abc#test', (string) $uri);
     }
 
     /**


### PR DESCRIPTION
Fix #219

This is enough to produce non-broken URLs.