### PR TITLE
Revert removals of `@final` annotations

### DIFF
--- a/doc/final.md
+++ b/doc/final.md
@@ -1,0 +1,20 @@
+# Final classes
+
+The `final` keyword was removed in version 1.4.0. It was replaced by `@final` annotation.
+This was done due popular demand, not because it is a good technical reason to
+extend the classes.
+
+This document will show the correct way to work with PSR-7 classes. The "correct way"
+refers to best practices and good software design. I strongly believe that one should
+be aware of how a problem *should* be solved, however, it is not needed to always
+implement that solution.
+
+## Extending classes
+
+You should never extend the classes, you should rather use composition or implement
+the interface yourself. Please refer to the [decorator pattern](https://refactoring.guru/design-patterns/decorator).
+
+## Mocking classes
+
+The PSR-7 classes are all value objects and they can be used without mocking. If
+one really needs to create a special scenario, one can mock the interface instead.

--- a/src/Factory/HttplugFactory.php
+++ b/src/Factory/HttplugFactory.php
@@ -14,6 +14,8 @@ use Psr\Http\Message\UriInterface;
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  * @author Martijn van der Ven <martijn@vanderven.se>
+ *
+ * @final This class should never be extended. See https://github.com/Nyholm/psr7/blob/master/doc/final.md
  */
 class HttplugFactory implements MessageFactory, StreamFactory, UriFactory
 {

--- a/src/Factory/Psr17Factory.php
+++ b/src/Factory/Psr17Factory.php
@@ -10,6 +10,8 @@ use Psr\Http\Message\{RequestFactoryInterface, RequestInterface, ResponseFactory
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  * @author Martijn van der Ven <martijn@vanderven.se>
+ *
+ * @final This class should never be extended. See https://github.com/Nyholm/psr7/blob/master/doc/final.md
  */
 class Psr17Factory implements RequestFactoryInterface, ResponseFactoryInterface, ServerRequestFactoryInterface, StreamFactoryInterface, UploadedFileFactoryInterface, UriFactoryInterface
 {

--- a/src/Request.php
+++ b/src/Request.php
@@ -9,6 +9,8 @@ use Psr\Http\Message\{RequestInterface, StreamInterface, UriInterface};
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  * @author Martijn van der Ven <martijn@vanderven.se>
+ *
+ * @final This class should never be extended. See https://github.com/Nyholm/psr7/blob/master/doc/final.md
  */
 class Request implements RequestInterface
 {

--- a/src/Response.php
+++ b/src/Response.php
@@ -10,6 +10,8 @@ use Psr\Http\Message\{ResponseInterface, StreamInterface};
  * @author Michael Dowling and contributors to guzzlehttp/psr7
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  * @author Martijn van der Ven <martijn@vanderven.se>
+ *
+ * @final This class should never be extended. See https://github.com/Nyholm/psr7/blob/master/doc/final.md
  */
 class Response implements ResponseInterface
 {

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -10,6 +10,8 @@ use Psr\Http\Message\{ServerRequestInterface, StreamInterface, UploadedFileInter
  * @author Michael Dowling and contributors to guzzlehttp/psr7
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  * @author Martijn van der Ven <martijn@vanderven.se>
+ *
+ * @final This class should never be extended. See https://github.com/Nyholm/psr7/blob/master/doc/final.md
  */
 class ServerRequest implements ServerRequestInterface
 {

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -12,6 +12,8 @@ use Symfony\Component\ErrorHandler\ErrorHandler as SymfonyErrorHandler;
  * @author Michael Dowling and contributors to guzzlehttp/psr7
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  * @author Martijn van der Ven <martijn@vanderven.se>
+ *
+ * @final This class should never be extended. See https://github.com/Nyholm/psr7/blob/master/doc/final.md
  */
 class Stream implements StreamInterface
 {

--- a/src/UploadedFile.php
+++ b/src/UploadedFile.php
@@ -10,6 +10,8 @@ use Psr\Http\Message\{StreamInterface, UploadedFileInterface};
  * @author Michael Dowling and contributors to guzzlehttp/psr7
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  * @author Martijn van der Ven <martijn@vanderven.se>
+ *
+ * @final This class should never be extended. See https://github.com/Nyholm/psr7/blob/master/doc/final.md
  */
 class UploadedFile implements UploadedFileInterface
 {

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -14,6 +14,8 @@ use Psr\Http\Message\UriInterface;
  * @author Matthew Weier O'Phinney
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  * @author Martijn van der Ven <martijn@vanderven.se>
+ *
+ * @final This class should never be extended. See https://github.com/Nyholm/psr7/blob/master/doc/final.md
  */
 class Uri implements UriInterface
 {


### PR DESCRIPTION
By keeping `@final`, we'll be able to add types to arguments without issuing a new major version. This is especially important since PSR-7 v1.1 and v2.0 have been released and we're likely going to have to adopt them soon.