### PR TITLE
Always store Response in memory

### DIFF
--- a/src/Stream.php
+++ b/src/Stream.php
@@ -81,7 +81,7 @@ class Stream implements StreamInterface
         }
 
         if (\is_string($body)) {
-            $resource = \fopen('php://temp', 'rw+');
+            $resource = \fopen('php://memory', 'rw+');
             \fwrite($resource, $body);
             \fseek($resource, 0);
             $body = $resource;

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -32,7 +32,7 @@ class StreamTest extends TestCase
         $this->assertTrue($stream->isReadable());
         $this->assertTrue($stream->isWritable());
         $this->assertTrue($stream->isSeekable());
-        $this->assertEquals('php://temp', $stream->getMetadata('uri'));
+        $this->assertEquals('php://memory', $stream->getMetadata('uri'));
         $this->assertTrue(\is_array($stream->getMetadata()));
         $this->assertSame(5, $stream->getSize());
         $this->assertFalse($stream->eof());


### PR DESCRIPTION
Response buffer should always stay in memory for two reasons:
- a) performance
- b) permission and/or read only disk

man https://www.php.net/manual/en/wrappers.php.php