### PR TITLE
Extract path normalization in a separate method

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -114,20 +114,7 @@ class Uri implements UriInterface
 
     public function getPath(): string
     {
-        $path = $this->path;
-
-        if ('' !== $path && '/' !== $path[0]) {
-            if ('' !== $this->host) {
-                // If the path is rootless and an authority is present, the path MUST be prefixed by "/"
-                $path = '/' . $path;
-            }
-        } elseif (isset($path[1]) && '/' === $path[1]) {
-            // If the path is starting with more than one "/", the
-            // starting slashes MUST be reduced to one.
-            $path = '/' . \ltrim($path, '/');
-        }
-
-        return $path;
+        return self::normalizePath($this->path, $this->host);
     }
 
     public function getQuery(): string

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -261,20 +261,7 @@ class Uri implements UriInterface
         }
 
         if ('' !== $path) {
-            if ('/' !== $path[0]) {
-                if ('' !== $authority) {
-                    // If the path is rootless and an authority is present, the path MUST be prefixed by "/"
-                    $path = '/' . $path;
-                }
-            } elseif (isset($path[1]) && '/' === $path[1]) {
-                if ('' === $authority) {
-                    // If the path is starting with more than one "/" and no authority is present, the
-                    // starting slashes MUST be reduced to one.
-                    $path = '/' . \ltrim($path, '/');
-                }
-            }
-
-            $uri .= $path;
+            $uri .= self::normalizePath($path, $authority);
         }
 
         if ('' !== $query) {
@@ -286,6 +273,27 @@ class Uri implements UriInterface
         }
 
         return $uri;
+    }
+
+    /**
+     * Normalize leading slashes in path.
+     */
+    private static function normalizePath(string $path, string $authority): string
+    {
+        if ('/' !== $path[0]) {
+            if ('' !== $authority) {
+                // If the path is rootless and an authority is present, the path MUST be prefixed by "/"
+                $path = '/' . $path;
+            }
+        } elseif (isset($path[1]) && '/' === $path[1]) {
+            if ('' === $authority) {
+                // If the path is starting with more than one "/" and no authority is present, the
+                // starting slashes MUST be reduced to one.
+                $path = '/' . \ltrim($path, '/');
+            }
+        }
+
+        return $path;
     }
 
     /**


### PR DESCRIPTION
Because the leading slashes path normalization seems to be duplicated, I would like to propose to extract it to a separate method.