### PR TITLE
Improve performance of creating streams from strings

### DIFF
--- a/src/Stream.php
+++ b/src/Stream.php
@@ -81,7 +81,14 @@ class Stream implements StreamInterface
         }
 
         if (\is_string($body)) {
-            $body = self::openZvalStream($body);
+            if (200000 <= \strlen($body)) {
+                $body = self::openZvalStream($body);
+            } else {
+                $resource = \fopen('php://memory', 'r+');
+                \fwrite($resource, $body);
+                \fseek($resource, 0);
+                $body = $resource;
+            }
         }
 
         if (!\is_resource($body)) {

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -29,16 +29,21 @@ class StreamTest extends TestCase
 
     public function testConstructorSeekWithStringContent()
     {
-        $stream = Stream::create('Hello');
+        $content = \str_repeat('Hello', 50000);
+        $stream = Stream::create($content);
         $this->assertTrue($stream->isReadable());
         $this->assertTrue($stream->isWritable());
         $this->assertTrue($stream->isSeekable());
         $this->assertEquals('Nyholm-Psr7-Zval://', $stream->getMetadata('uri'));
         $this->assertTrue(\is_array($stream->getMetadata()));
-        $this->assertSame(5, $stream->getSize());
+        $this->assertSame(250000, $stream->getSize());
         $this->assertFalse($stream->eof());
-        $this->assertSame('Hello', $stream->getContents());
+        $this->assertSame($content, $stream->getContents());
         $stream->close();
+
+        $stream = Stream::create('Hello');
+        $this->assertEquals('php://memory', $stream->getMetadata('uri'));
+        $this->assertSame('Hello', $stream->getContents());
     }
 
     public function testStreamClosesHandleOnDestruct()


### PR DESCRIPTION
Using https://github.com/devanych/psr-http-benchmark, I figured out that for strings smaller than ~200k, `php://memory` is faster than the custom zval stream. Past this threshold, zval stream is way faster thanks to copy-on-write.