### PR TITLE
Deprecate HttplugFactory and make dependency on php-http/message-factory optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 1.8.0
+
+- Deprecate HttplugFactory, use Psr17Factory instead
+- Make depencendy on php-http/message-factory optional
+
 ## 1.7.0
 
 - Bump to PHP 7.2 minimum

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
     "require": {
         "php": ">=7.2",
         "psr/http-message": "^1.1 || ^2.0",
-        "php-http/message-factory": "^1.0",
         "psr/http-factory": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.5 || 8.5 || 9.4",
-        "php-http/psr7-integration-tests": "^1.0@dev",
+        "phpunit/phpunit": "^7.5 || ^8.5 || ^9.4",
+        "php-http/message-factory": "^1.0",
+        "php-http/psr7-integration-tests": "^1.0",
         "http-interop/http-factory-tests": "^0.9",
         "symfony/error-handler": "^4.4"
     },
@@ -43,7 +43,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.7-dev"
+            "dev-master": "1.8-dev"
         }
     }
 }

--- a/src/Factory/HttplugFactory.php
+++ b/src/Factory/HttplugFactory.php
@@ -11,11 +11,19 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
 
+if (!\interface_exists(MessageFactory::class)) {
+    throw new \LogicException('You cannot use "Nyholm\Psr7\Factory\HttplugFactory" as the "php-http/message-factory" package is not installed. Try running "composer require php-http/message-factory". Note that this package is deprecated, use "psr/http-factory" instead');
+}
+
+@\trigger_error('Class "Nyholm\Psr7\Factory\HttplugFactory" is deprecated since version 1.8, use "Nyholm\Psr7\Factory\Psr17Factory" instead.', \E_USER_DEPRECATED);
+
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  * @author Martijn van der Ven <martijn@vanderven.se>
  *
  * @final This class should never be extended. See https://github.com/Nyholm/psr7/blob/master/doc/final.md
+ *
+ * @deprecated since version 1.8, use Psr17Factory instead
  */
 class HttplugFactory implements MessageFactory, StreamFactory, UriFactory
 {


### PR DESCRIPTION
Follows https://github.com/php-http/message-factory/pull/42